### PR TITLE
Cache the blog feed requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Markdown==3.1
 prometheus_client==0.6.0
 prometheus-flask-exporter==0.7.1
 raven[flask]==6.10.0
+requests-cache==0.4.13
 statsd==3.3.0
 talisker==0.14.2
 theblues==0.5.1

--- a/webapp/jaasai/views.py
+++ b/webapp/jaasai/views.py
@@ -115,6 +115,7 @@ def support():
 @jaasai.route("/blog/feed")
 def blog_feed():
     feed_url = "https://admin.insights.ubuntu.com/tag/juju/feed"
+    # Timeout after 3 seconds if there is no response.
     response = cached_session.get(feed_url, timeout=3)
     feed = feedparser.parse(response.text)
     response = None

--- a/webapp/jaasai/views.py
+++ b/webapp/jaasai/views.py
@@ -1,11 +1,20 @@
+import datetime
 import feedparser
 import os
+import requests_cache
 from flask import Blueprint, jsonify, render_template
 
 from webapp.experts import get_experts
 
 jaasai = Blueprint(
     "jaasai", __name__, template_folder="/templates", static_folder="/static"
+)
+
+cached_session = requests_cache.CachedSession(
+    name="hour-cache",
+    expire_after=datetime.timedelta(hours=1),
+    backend="memory",
+    old_data_on_error=True,
 )
 
 
@@ -106,7 +115,8 @@ def support():
 @jaasai.route("/blog/feed")
 def blog_feed():
     feed_url = "https://admin.insights.ubuntu.com/tag/juju/feed"
-    feed = feedparser.parse(feed_url)
+    response = cached_session.get(feed_url, timeout=3)
+    feed = feedparser.parse(response.text)
     response = None
     if feed.bozo == 1:
         response = {"error": feed.bozo_exception.getMessage()}


### PR DESCRIPTION
## Done

- Add an in-memory cache for blog rss feed requests.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open /blog/feed and note how long it takes.
- Refresh the page, it should return immediately.

## Details

Fixes: #165.
