### PR TITLE
Implement the wider grid in Vanilla

### DIFF
--- a/static/js/src/app.js
+++ b/static/js/src/app.js
@@ -5,7 +5,7 @@ import showContactDetails from './modules/show-contact-details';
 import copySnippet from './modules/copy-snippet';
 
 // Instantiate modules
-createNav({maxWidth: '64.875rem', showLogins: false});
+createNav({maxWidth: '72rem', showLogins: false});
 showContactDetails();
 copySnippet();
 searchPanel();

--- a/static/sass/custom/_header.scss
+++ b/static/sass/custom/_header.scss
@@ -12,7 +12,7 @@ $color--background: #333333;
     flex-direction: column;
     padding: 0 1.5rem;
     margin: auto;
-    max-width: 64.875rem;
+    max-width: $grid-max-width;
   }
 
   [class*='p-header__toggle'] {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -277,8 +277,7 @@ div .p-accordion__tab[aria-expanded] {
     padding-right: 2rem;
   }
 
-  &:after {
-    // sass-lint:disable-line pseudo-element
+  &::after {
     content: url('https://assets.ubuntu.com/v1/0d85260e-play-icon.svg'); // sass-lint:disable-line no-url-protocols no-url-domains
     display: inline-block;
     height: 1rem;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -5,6 +5,7 @@ $asset-path: '/static/';
 // Override local variables
 $color-navigation-background: #333;
 $color-kubernetes: #2e69ea;
+$grid-max-width: 72rem;
 
 // Set the mobile nav breakpoint to handle the large number of nav items.
 @import 'vanilla-framework/scss/settings_breakpoints';
@@ -276,7 +277,8 @@ div .p-accordion__tab[aria-expanded] {
     padding-right: 2rem;
   }
 
-  &:after { // sass-lint:disable-line pseudo-element
+  &:after {
+    // sass-lint:disable-line pseudo-element
     content: url('https://assets.ubuntu.com/v1/0d85260e-play-icon.svg'); // sass-lint:disable-line no-url-protocols no-url-domains
     display: inline-block;
     height: 1rem;


### PR DESCRIPTION
## Done
Widen the max grid width to `72rem`.

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check that the default row width is `72rem`
- See that the navigation matches
- Check the global-nav also matches the new max-width
- Check the pages look ok

## Details
Fixes #169 
Fixes #170 
