### PR TITLE
Add supported cards

### DIFF
--- a/templates/shared/_plan-card.html
+++ b/templates/shared/_plan-card.html
@@ -1,0 +1,13 @@
+<div class="p-card expert-card has-strap">
+  <div class="expert__strap">
+    Managed solution
+  </div>
+  <h3 style="margin-top:2rem">Approx ${{ context.entity.supported_price }}\m</h3>
+  <h4>Default plan with standard support</h4>
+  <hr>
+  <p>{{ context.entity.supported_description|safe }}</p>
+  <a href="{{ external_urls.gui }}?deploy-target={{ context.entity.id }}" class="p-button--positive" rel="nofollow">
+    Deploy {{ context.entity.display_name }}
+  </a>
+  <p><a href="{{ context.expert.page_url }}">Learn more about <span style="text-transform:capitalize">{{ context.expert.name }}</span> support</a></p>
+</div>

--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -46,6 +46,11 @@
             </span>
           </li>
         {% endif %}
+        {% if context.entity.plans %}
+          <li class="p-inline-list__item">
+            <a href="#plans">{{ context.entity.plans|length }} plan{{ context.entity.plans|length|pluralize }} available</a>
+          </li>
+        {% endif %}
       </ul>
       {% if context.entity.series %}
       Supports:

--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -46,11 +46,6 @@
             </span>
           </li>
         {% endif %}
-        {% if context.entity.plans %}
-          <li class="p-inline-list__item">
-            <a href="#plans">{{ context.entity.plans|length }} plan{{ context.entity.plans|length|pluralize }} available</a>
-          </li>
-        {% endif %}
       </ul>
       {% if context.entity.series %}
       Supports:

--- a/templates/store/bundle-details.html
+++ b/templates/store/bundle-details.html
@@ -29,6 +29,9 @@
     </div>
     <div class="col-4">
       {% if context.expert %}
+        {% if context.entity.supported %}
+          {% include "shared/_plan-card.html" %}
+        {% endif %}
         <div class="p-card expert-card has-strap">
           <div class="expert__strap">
             Juju expert partners

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -97,27 +97,7 @@
       {% endif %}
     </div>
     <aside class="col-4">
-      {% if context.entity.plans %}
-        <div class="p-card expert-card has-strap">
-          <div class="expert__strap">
-            Managed solution
-          </div>
-          {% for plan in context.entity.plans %}
-            <h3 style="margin-top:2rem">
-              {% for price in plan.prices %}
-                {{ price.amount }}
-                {% if price.quantity %}
-                  / {{ price.quantity }}
-                {% endif %}
-              {% endfor %}
-            </h3>
-            <hr />
-            <p><strong>{{ plan.url }}</strong></p>
-            <p>{{ plan.description }}</p>
-          {% endfor %}
-        </div>
-      {% endif %}
-      {% if context.expert and context.entity.plans %}
+      {% if context.expert %}
         <div class="p-card expert-card has-strap">
           <div class="expert__strap">
             Juju expert partners

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -97,6 +97,26 @@
       {% endif %}
     </div>
     <aside class="col-4">
+      {% if context.entity.plans %}
+        <div class="p-card expert-card has-strap">
+          <div class="expert__strap">
+            Managed solution
+          </div>
+          {% for plan in context.entity.plans %}
+            <h3 style="margin-top:2rem">
+              {% for price in plan.prices %}
+                {{ price.amount }}
+                {% if price.quantity %}
+                  / {{ price.quantity }}
+                {% endif %}
+              {% endfor %}
+            </h3>
+            <hr />
+            <p><strong>{{ plan.url }}</strong></p>
+            <p>{{ plan.description }}</p>
+          {% endfor %}
+        </div>
+      {% endif %}
       {% if context.expert and context.entity.plans %}
         <div class="p-card expert-card has-strap">
           <div class="expert__strap">

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -98,6 +98,9 @@
     </div>
     <aside class="col-4">
       {% if context.expert %}
+        {% if context.entity.supported %}
+          {% include "shared/_plan-card.html" %}
+        {% endif %}
         <div class="p-card expert-card has-strap">
           <div class="expert__strap">
             Juju expert partners

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -97,7 +97,7 @@
       {% endif %}
     </div>
     <aside class="col-4">
-      {% if context.expert %}
+      {% if context.expert and context.entity.plans %}
         <div class="p-card expert-card has-strap">
           <div class="expert__strap">
             Juju expert partners

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -117,12 +117,12 @@ class TestStoreModels(unittest.TestCase):
         charm_data["Meta"]["extra-info"]["price"] = "99"
         charm_data["Meta"]["extra-info"][
             "description"
-        ] = "Great ol' charm this one"
+        ] = "Great ol' charm\nthis one"
         charm = models._parse_charm_data(charm_data)
         self.assertTrue(charm["supported"])
         self.assertEqual(charm["supported_price"], "99")
         self.assertEqual(
-            charm["supported_description"], "Great ol' charm this one"
+            charm["supported_description"], "<p>Great ol' charm<br />\nthis one</p>"
         )
 
     def test_parse_bundle_data(self):
@@ -174,10 +174,10 @@ class TestStoreModels(unittest.TestCase):
         bundle_data["Meta"]["extra-info"]["price"] = "99"
         bundle_data["Meta"]["extra-info"][
             "description"
-        ] = "Great ol' bundle this one"
+        ] = "Great ol' bundle\nthis one"
         bundle = models._parse_bundle_data(bundle_data)
         self.assertTrue(bundle["supported"])
         self.assertEqual(bundle["supported_price"], "99")
         self.assertEqual(
-            bundle["supported_description"], "Great ol' bundle this one"
+            bundle["supported_description"], "<p>Great ol' bundle<br />\nthis one</p>"
         )

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -3,7 +3,6 @@ import unittest
 from tests.store.testdata import bundle_data, charm_data, search_data
 from unittest.mock import patch
 
-from theblues.plans import Plan
 from webapp.store import models
 
 
@@ -113,6 +112,18 @@ class TestStoreModels(unittest.TestCase):
             ],
         )
 
+    def test_parse_charm_data_supported(self):
+        charm_data["Meta"]["extra-info"]["supported"] = "true"
+        charm_data["Meta"]["extra-info"]["price"] = "99"
+        charm_data["Meta"]["extra-info"][
+            "description"
+        ] = "Great ol' charm this one"
+        charm = models._parse_charm_data(charm_data)
+        self.assertTrue(charm["supported"])
+        self.assertEqual(charm["supported_price"], "99")
+        self.assertEqual(
+            charm["supported_description"], "Great ol' charm this one"
+        )
 
     def test_parse_bundle_data(self):
         bundle = models._parse_bundle_data(bundle_data)
@@ -157,3 +168,16 @@ class TestStoreModels(unittest.TestCase):
         self.assertIsNone(bundle["tags"])
         self.assertEqual(bundle["units"], 10)
         self.assertEqual(bundle["url"], "canonical-kubernetes/bundle/466")
+
+    def test_parse_bundle_data_supported(self):
+        bundle_data["Meta"]["extra-info"]["supported"] = "true"
+        bundle_data["Meta"]["extra-info"]["price"] = "99"
+        bundle_data["Meta"]["extra-info"][
+            "description"
+        ] = "Great ol' bundle this one"
+        bundle = models._parse_bundle_data(bundle_data)
+        self.assertTrue(bundle["supported"])
+        self.assertEqual(bundle["supported_price"], "99")
+        self.assertEqual(
+            bundle["supported_description"], "Great ol' bundle this one"
+        )

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -113,42 +113,6 @@ class TestStoreModels(unittest.TestCase):
             ],
         )
 
-    @patch("theblues.charmstore.CharmStore.files")
-    @patch("theblues.plans.Plans.get_plans")
-    def test_parse_charm_data_plans(self, mock_get_plans, mock_files):
-        mock_files.return_value = {"metrics.yaml": "metrics.yaml"}
-        mock_get_plans.return_value = (
-            Plan(
-                "http://example.com/plan1",
-                (),
-                datetime.datetime.utcnow(),
-                "The first test plan.",
-                "0.50/support",
-            ),
-            Plan(
-                "http://example.com/plan2",
-                (),
-                datetime.datetime.utcnow(),
-                "The second test plan.",
-                "Free",
-            ),
-        )
-        charm = models._parse_charm_data(charm_data, include_files=True)
-        self.assertEqual(
-            charm.get("plans"),
-            [
-                {
-                    "url": "http://example.com/plan1",
-                    "description": "The first test plan.",
-                    "prices": [{"amount": "0.50", "quantity": "support"}],
-                },
-                {
-                    "url": "http://example.com/plan2",
-                    "description": "The second test plan.",
-                    "prices": [{"amount": "Free", "quantity": None}],
-                },
-            ],
-        )
 
     def test_parse_bundle_data(self):
         bundle = models._parse_bundle_data(bundle_data)
@@ -193,40 +157,3 @@ class TestStoreModels(unittest.TestCase):
         self.assertIsNone(bundle["tags"])
         self.assertEqual(bundle["units"], 10)
         self.assertEqual(bundle["url"], "canonical-kubernetes/bundle/466")
-
-    @patch("theblues.charmstore.CharmStore.files")
-    @patch("theblues.plans.Plans.get_plans")
-    def test_parse_bundle_data_plans(self, mock_get_plans, mock_files):
-        mock_files.return_value = {"metrics.yaml": "metrics.yaml"}
-        mock_get_plans.return_value = (
-            Plan(
-                "http://example.com/plan1",
-                (),
-                datetime.datetime.utcnow(),
-                "The first test plan.",
-                "0.50/support",
-            ),
-            Plan(
-                "http://example.com/plan2",
-                (),
-                datetime.datetime.utcnow(),
-                "The second test plan.",
-                "Free",
-            ),
-        )
-        bundle = models._parse_bundle_data(bundle_data, include_files=True)
-        self.assertEqual(
-            bundle.get("plans"),
-            [
-                {
-                    "url": "http://example.com/plan1",
-                    "description": "The first test plan.",
-                    "prices": [{"amount": "0.50", "quantity": "support"}],
-                },
-                {
-                    "url": "http://example.com/plan2",
-                    "description": "The second test plan.",
-                    "prices": [{"amount": "Free", "quantity": None}],
-                },
-            ],
-        )

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -1,4 +1,3 @@
-import datetime
 import unittest
 from tests.store.testdata import bundle_data, charm_data, search_data
 from unittest.mock import patch
@@ -122,7 +121,8 @@ class TestStoreModels(unittest.TestCase):
         self.assertTrue(charm["supported"])
         self.assertEqual(charm["supported_price"], "99")
         self.assertEqual(
-            charm["supported_description"], "<p>Great ol' charm<br />\nthis one</p>"
+            charm["supported_description"],
+            "<p>Great ol' charm<br />\nthis one</p>",
         )
 
     def test_parse_bundle_data(self):
@@ -179,5 +179,6 @@ class TestStoreModels(unittest.TestCase):
         self.assertTrue(bundle["supported"])
         self.assertEqual(bundle["supported_price"], "99")
         self.assertEqual(
-            bundle["supported_description"], "<p>Great ol' bundle<br />\nthis one</p>"
+            bundle["supported_description"],
+            "<p>Great ol' bundle<br />\nthis one</p>",
         )

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -147,7 +147,7 @@ def _parse_bundle_data(bundle_data, include_files=False):
     if commercial:
         try:
             entity_plans = parse_prices(plans.get_plans(ref))
-        except ServerError as err:
+        except ServerError:
             pass
     return {
         "archive_url": cs.archive_url(ref),

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -170,7 +170,8 @@ def _parse_bundle_data(bundle_data, include_files=False):
         "series": [bundle_metadata.get("Series")],
         "supported": supported,
         "supported_price": supported_price,
-        "supported_description": supported_description and _render_markdown(supported_description),
+        "supported_description": supported_description
+        and _render_markdown(supported_description),
         "services": _parseBundleServices(bundle_metadata["applications"]),
         "tags": bundle_metadata.get("Tags"),
         "units": meta.get("bundle-unit-count", {}).get("Count", ""),
@@ -244,7 +245,8 @@ def _parse_charm_data(charm_data, include_files=False):
         "series": meta.get("supported-series", {}).get("SupportedSeries"),
         "supported": supported,
         "supported_price": supported_price,
-        "supported_description": supported_description and _render_markdown(supported_description),
+        "supported_description": supported_description
+        and _render_markdown(supported_description),
         # Some charms do not have tags, so fall back to categories if they
         # exist (mostly on older charms).
         "is_charm": True,

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -1,15 +1,17 @@
 import collections
+import gfm
 import os
 import re
 
-import gfm
 from jujubundlelib import references
 from theblues.charmstore import CharmStore
 from theblues.errors import EntityNotFound, ServerError
+from theblues.plans import Plans
 from theblues.terms import Terms
 
 
 cs = CharmStore("https://api.jujucharms.com/v5")
+plans = Plans("https://api.jujucharms.com/omnibus/")
 terms = Terms("https://api.jujucharms.com/terms/")
 
 
@@ -135,8 +137,19 @@ def _parse_bundle_data(bundle_data, include_files=False):
         "url": "{}/{}".format(ref.name, int(revision_list[0].split("-")[-1])),
     }
     description = bundle_metadata.get("Description")
-
-    bundle = {
+    files = None
+    readme = None
+    if include_files:
+        files = _get_entity_files(ref, meta.get("manifest"))
+        readme = _render_markdown(cs.entity_readme_content(bundle_id))
+    commercial = is_commercial(files)
+    entity_plans = None
+    if commercial:
+        try:
+            entity_plans = parse_prices(plans.get_plans(ref))
+        except ServerError as err:
+            pass
+    return {
         "archive_url": cs.archive_url(ref),
         "bundle_data": bundle_data,
         "bundle_visulisation": getBundleVisualization(ref),
@@ -146,11 +159,15 @@ def _parse_bundle_data(bundle_data, include_files=False):
         # description exists before trying to render the Markdown.
         "description": _render_markdown(description) if description else None,
         "display_name": _get_display_name(name),
+        "files": files,
         "id": bundle_data.get("Id"),
         "is_charm": False,
+        "is_commercial": commercial,
         "latest_revision": latest_revision,
         "owner": meta.get("owner", {}).get("User"),
+        "plans": entity_plans,
         "promulgated": meta.get("promulgated", {}).get("Promulgated"),
+        "readme": readme,
         "revision_number": ref.revision,
         # The series is an array to match the charm data.
         "series": [bundle_metadata.get("Series")],
@@ -159,13 +176,6 @@ def _parse_bundle_data(bundle_data, include_files=False):
         "units": meta.get("bundle-unit-count", {}).get("Count", ""),
         "url": ref.jujucharms_id(),
     }
-    if include_files:
-        bundle["files"] = _get_entity_files(ref, meta.get("manifest"))
-        bundle["readme"] = _render_markdown(
-            cs.entity_readme_content(bundle_id)
-        )
-
-    return bundle
 
 
 def _parseBundleServices(services):
@@ -194,8 +204,19 @@ def _parse_charm_data(charm_data, include_files=False):
         "url": "{}/{}".format(name, int(revision_list[0].split("-")[-1])),
     }
     description = charm_metadata.get("Description")
-
-    charm = {
+    files = None
+    readme = None
+    if include_files:
+        files = _get_entity_files(ref, meta.get("manifest"))
+        readme = _render_markdown(cs.entity_readme_content(charm_id))
+    commercial = is_commercial(files)
+    entity_plans = None
+    if commercial:
+        try:
+            entity_plans = parse_prices(plans.get_plans(ref))
+        except ServerError as err:
+            pass
+    return {
         "archive_url": cs.archive_url(ref),
         "bugs_url": bugs_url,
         "bzr_url": bzr_url,
@@ -206,14 +227,18 @@ def _parse_charm_data(charm_data, include_files=False):
         # description exists before trying to render the Markdown.
         "description": _render_markdown(description) if description else None,
         "display_name": _get_display_name(name),
+        "files": files,
         "homepage": homepage,
         "icon": cs.charm_icon_url(charm_id),
         "id": charm_id,
+        "is_commercial": commercial,
         "latest_revision": latest_revision,
         "options": meta.get("charm-config", {}).get("Options"),
         "owner": meta.get("owner", {}).get("User"),
+        "plans": entity_plans,
         "promulgated": meta.get("promulgated", {}).get("Promulgated"),
         "provides": charm_metadata.get("Provides"),
+        "readme": readme,
         "requires": charm_metadata.get("Requires"),
         "resources": _extract_resources(ref, meta.get("resources", {})),
         "revision_list": revision_list,
@@ -228,11 +253,61 @@ def _parse_charm_data(charm_data, include_files=False):
         "url": ref.jujucharms_id(),
     }
 
-    if include_files:
-        charm["files"] = _get_entity_files(ref, meta.get("manifest"))
-        charm["readme"] = _render_markdown(cs.entity_readme_content(charm_id))
 
-    return charm
+def is_commercial(files):
+    """Matches what is happening on the GUI side; right now we're just
+        checking to see if there's a metrics file. In the future this
+        commercial check will change probably by checking the commercial
+        flag.
+        :param files: the files for an entity.
+        :returns: A boolean for whether the entity is commercial.
+    """
+    files = files or {}
+    return "metrics.yaml" in files
+
+
+def parse_prices(plans):
+    """Price is a simple string; we need to parse out:
+        1) Multiple prices.
+        2) Break each price down into an amount and quantity.
+        Parsing the prices allows us to display a nicer UI.
+        :param plans: iterable plans attached to the entity.
+        :returns: a list of plans with the parsed prices.
+    """
+    formatted_plans = []
+    for plan in plans:
+        price = plan.price
+        if not price:
+            continue
+        # We know that multiple prices use ';' as a delimiter:
+        # that is setup programmatically in omnibus and should be
+        # dependable. The only caveat is that end users can't use
+        # a ';' in their price string.
+        prices = price.split(";")
+        formatted_prices = []
+        for p in prices:
+            # Though the string is free-form text, we're defining
+            # a convention here: {price}/{quantity}. If there is no
+            # '/', then treat the entire string as the amount.
+            # For example, a price of 'Free' becomes
+            # {amount: 'Free', quantity: None}
+            try:
+                amount, quantity = p.split("/", 1)
+            except ValueError:
+                amount = p
+                quantity = None
+            formatted_prices.append(dict(amount=amount, quantity=quantity))
+        # We drop the following fields because they're currently
+        # not used in the UI: plan (the underlying yaml) and
+        # created_on.
+        formatted_plans.append(
+            dict(
+                url=plan.url,
+                description=plan.description,
+                prices=formatted_prices,
+            )
+        )
+    return formatted_plans
 
 
 def _parse_term_ids(term_ids):

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -170,7 +170,7 @@ def _parse_bundle_data(bundle_data, include_files=False):
         "series": [bundle_metadata.get("Series")],
         "supported": supported,
         "supported_price": supported_price,
-        "supported_description": supported_description,
+        "supported_description": supported_description and _render_markdown(supported_description),
         "services": _parseBundleServices(bundle_metadata["applications"]),
         "tags": bundle_metadata.get("Tags"),
         "units": meta.get("bundle-unit-count", {}).get("Count", ""),
@@ -244,7 +244,7 @@ def _parse_charm_data(charm_data, include_files=False):
         "series": meta.get("supported-series", {}).get("SupportedSeries"),
         "supported": supported,
         "supported_price": supported_price,
-        "supported_description": supported_description,
+        "supported_description": supported_description and _render_markdown(supported_description),
         # Some charms do not have tags, so fall back to categories if they
         # exist (mostly on older charms).
         "is_charm": True,

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -214,7 +214,7 @@ def _parse_charm_data(charm_data, include_files=False):
     if commercial:
         try:
             entity_plans = parse_prices(plans.get_plans(ref))
-        except ServerError as err:
+        except ServerError:
             pass
     return {
         "archive_url": cs.archive_url(ref),


### PR DESCRIPTION
## Done

- Show plans on supported charms (blues_browser had code for bundles as well, I did not add this as it doesn't seem to ever actually be able to be shown).
- Only show the expert card on supported charms.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open models.py and update the charmstore URL to use staging (https://api.staging.jujucharms.com/v5)
- open bundle-details.html
- move the `{% if context.entity.supported %}` block up out of the `{% if context.expert %}` block
- visit /u/hatch/estest/bundle/1
- you should see a "Managed solution" card on the right

## Details

- Fixes: #112.
- Fixes: #166.