### PR TITLE
Fix revision info

### DIFF
--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -32,7 +32,7 @@
                     'eventAction' : 'Goto latest version',
                     'eventLabel' : 'Latest version (#ID)',
                     'eventValue' : '{{ context.entity.latest_revision['full_id'] }}'
-                  });"><strong>Latest version</strong> (#{{ context.entity.latest_revision }})
+                  });"><strong>Latest version</strong> (#{{ context.entity.latest_revision.id }})
               </a>
             </span>
           </li>

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -4,7 +4,7 @@ import re
 
 import gfm
 from jujubundlelib import references
-from theblues.charmstore import CharmStore
+from theblues.charmstore import CharmStore, DEFAULT_INCLUDES
 from theblues.errors import EntityNotFound, ServerError
 from theblues.terms import Terms
 
@@ -85,8 +85,10 @@ def get_user_entities(username):
 
 
 def get_charm_or_bundle(reference):
+    includes = DEFAULT_INCLUDES[:]
+    includes.append("revision-info")
     try:
-        entity_data = cs.entity(reference, True)
+        entity_data = cs.entity(reference, True, includes=includes)
         return _parse_charm_or_bundle(entity_data, include_files=True)
     except EntityNotFound:
         return None


### PR DESCRIPTION
## Done

- Get the revision info and correctly display it on charms and bundles.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open a charm or bundle
- Under the charm/bundle name it should say "Latest version" and have a number.

## Details

- Fixes: #85.
