### PR TITLE
Update header items

### DIFF
--- a/templates/jaasai/how-it-works.html
+++ b/templates/jaasai/how-it-works.html
@@ -1,5 +1,7 @@
 {% extends "_layout.html" %}
 
+{% set active_section = "how-it-works" %}
+
 {% block title %}How it works{% endblock %}
 
 {% block content %}

--- a/templates/shared/navigation.html
+++ b/templates/shared/navigation.html
@@ -10,6 +10,12 @@
     About
   </a>
 </div>
+<div class="p-header__nav-item" role="menuitem">
+  <a href="{{ url_for('jaasai.how_it_works') }}"
+    class="{% if active_section == 'how-it-works' %}active{% endif %}">
+    How it works
+  </a>
+</div>
 <div class="p-header__nav-item is-secondary-link" role="menuitem">
   <a class="p-link--external" href="{{ external_urls.discourse }}">
     Discourse

--- a/templates/shared/navigation.html
+++ b/templates/shared/navigation.html
@@ -28,6 +28,6 @@
 </div>
 <div class="p-header__nav-item" role="menuitem">
   <a class="p-link--external" href="{{ external_urls.gui }}">
-    Getting started
+    Get started
   </a>
 </div>


### PR DESCRIPTION
## Done

- Rename "Getting started" to "Get started" in the main nav.
- Add "How it works" item to the main nav.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open the home page.
- Check that there is a "How it works" item in the main nav.
- Check that there is an item named "Get started" (not "Getting started").

## Details

- Fixes: #594.
- Fixes: #595.
