### PR TITLE
Improve search quality

### DIFF
--- a/tests/store/test_views.py
+++ b/tests/store/test_views.py
@@ -1,6 +1,6 @@
 from flask import url_for
 from flask_testing import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import call, MagicMock, patch
 
 from tests.store.testdata import bundle_data, charm_data, user_entities_data
 from theblues.errors import ServerError
@@ -34,6 +34,21 @@ class StoreViews(TestCase):
         }
         response = self.client.get(url_for("jaasstore.search", q="k8s"))
         self.assertEqual(response.status_code, 200)
+
+    @patch("webapp.store.models.search_entities")
+    def test_search_entity(self, mock_search_entities):
+        mock_search_entities.return_value = {
+            "recommended": [],
+            "community": [],
+        }
+        response = self.client.get(
+            url_for("jaasstore.search", q="cs:~wombat/k8s")
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mock_search_entities.call_count, 2)
+        self.assertEqual(
+            mock_search_entities.call_args_list[1], call("k8s", owner="wombat")
+        )
 
     @patch("theblues.charmstore.CharmStore.list")
     def test_user_details(self, mock_list):

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -21,6 +21,7 @@ def search_entities(
     tags=None,
     sort=None,
     series=None,
+    owner=None,
     promulgated_only=None,
 ):
     includes = [
@@ -37,6 +38,7 @@ def search_entities(
             doc_type=entity_type,
             includes=includes,
             limit=SEARCH_LIMIT,
+            owner=owner,
             promulgated_only=False,
             series=series,
             sort=sort,
@@ -49,6 +51,32 @@ def search_entities(
         return results
     except EntityNotFound:
         return None
+
+
+def get_reference(entity):
+    """From a string, see if we can make an entity reference out of it, using
+        all possible methods.
+        :param string: a string to turn into a reference.
+        :returns: A reference or None.
+    """
+    reference = None
+    try:
+        reference = references.Reference.from_jujucharms_url(entity)
+    except ValueError:
+        pass
+    try:
+        reference = references.Reference.from_string(entity)
+    except ValueError:
+        pass
+    try:
+        reference = references.Reference.from_jujucharms_url(entity)
+    except ValueError:
+        pass
+    try:
+        reference = references.Reference.from_fully_qualified_url(entity)
+    except ValueError:
+        pass
+    return reference
 
 
 def _group_status(entities):

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -21,7 +21,8 @@ def store():
 
 @jaasstore.route("/search")
 def search():
-    query = request.args.get("q", "").replace("/", " ")
+    query = request.args.get("q", "")
+    search_terms = query.replace("/", " ").replace("-", " ")
     entity_type = request.args.get("type", None)
     if entity_type not in ["charm", "bundle"]:
         entity_type = None
@@ -36,7 +37,7 @@ def search():
         results = models.fetch_requires(requires)
     else:
         results = models.search_entities(
-            query,
+            search_terms,
             entity_type=entity_type,
             tags=tags,
             sort=sort,

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -44,6 +44,15 @@ def search():
             series=series,
             promulgated_only=False,
         )
+    if len(results["recommended"]) + len(results["community"]) == 0:
+        # If there are no results then check to see if this string could be a
+        # bundle/charm id and do another search. This is something the
+        # charmstore should handle internally, but until it does, do it here.
+        reference = models.get_reference(query)
+        if reference is not None:
+            results = models.search_entities(
+                reference.name, owner=reference.user
+            )
     return render_template(
         "store/search.html",
         context={


### PR DESCRIPTION
## Done

- Replace hyphens with spaces in searches.
- Attempt an entity search if there are no results.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Do a search for "glance-simplestreams-sync" you should get a result.
- Do a search for "cs:~boucherv29/keepalived-19" and you should also get a result (you can also search for other user urls e.g. search for "/u/hatch/large-ghost/bundle/1").
- Do some normal searches and the results should be unchanged.

## Details

- Fixes: #130.
