### PR TITLE
Update home background and fix mobile

### DIFF
--- a/static/sass/custom/_homepage-hero-promo.scss
+++ b/static/sass/custom/_homepage-hero-promo.scss
@@ -20,10 +20,6 @@
 
 .homepage-hero-image-wrap {
   position: static;
-
-  @media (max-width: $breakpoint-medium) {
-    display: none;
-  }
 }
 
 .homepage-hero-image {
@@ -33,6 +29,12 @@
   top: 0;
   width: 55vw;
 
+  @media (max-width: $breakpoint-medium) {
+    left: -1.5rem;
+    position: relative;
+    width: 100vw;
+    max-width: none;
+  }
 }
 
 .homepage-hero-promos {

--- a/static/sass/custom/_homepage-hero-promo.scss
+++ b/static/sass/custom/_homepage-hero-promo.scss
@@ -19,43 +19,20 @@
 }
 
 .homepage-hero-image-wrap {
-  min-height: 16rem;
-  position: relative;
+  position: static;
 
-  @media (min-width: $breakpoint-medium) {
-    position: static;
+  @media (max-width: $breakpoint-medium) {
+    display: none;
   }
 }
 
 .homepage-hero-image {
+  max-width: 600px;
   position: absolute;
-  right: 0;
+  right: -1rem;
+  top: 0;
+  width: 55vw;
 
-  @media (max-width: $breakpoint-medium) {
-    top: -5rem;
-    z-index: 999;
-  }
-
-  @media (min-width: $breakpoint-medium) {
-    max-width: 600px;
-    right: 0;
-    top: 1rem;
-    width: 65vw;
-  }
-
-  @media (min-width: 940px) {
-    max-width: 600px;
-    right: -1rem;
-    top: 0;
-  }
-}
-
-.homepage-hero-card {
-  position: relative;
-
-  @media (max-width: 940px) {
-    z-index: 999;
-  }
 }
 
 .homepage-hero-promos {

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-  <div class="p-strip--image is-light" style="position:relative;background-image:url('https://assets.ubuntu.com/v1/f1511329-Background.svg') }}')">
+  <div class="p-strip--image is-light" style="position:relative;overflow:hidden;background-image:url('https://assets.ubuntu.com/v1/cf344c3f-bg.svg')">
     <div class="row" style="position:relative">
       <div class="col-6">
         <div class="p-strip is-shallow u-no-padding--top u-no-padding--bottom">

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-  <div class="p-strip--image is-light" style="position:relative;overflow:hidden;background-image:url('https://assets.ubuntu.com/v1/cf344c3f-bg.svg')">
+  <div class="p-strip--image is-light" style="overflow:hidden;background-image:url('https://assets.ubuntu.com/v1/cf344c3f-bg.svg')">
     <div class="row" style="position:relative">
       <div class="col-6">
         <div class="p-strip is-shallow u-no-padding--top u-no-padding--bottom">


### PR DESCRIPTION
## Done

- Add the new header background on the home page.
- Fix the home header diagram on mobile.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check that there is a grey background behind the header intro.
- Resize the page from desktop all the way down to mobile.
- The intro should look OK at all sizes and the diagram should eventually disappear.

## Details

- Fixes: https://github.com/canonical-web-and-design/juju-squad/issues/599.
- Fixes: https://github.com/canonical-web-and-design/juju-squad/issues/600
