### PR TITLE
Add ‘juju deploy’ to copy snippet in entity header

### DIFF
--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -58,7 +58,7 @@
     </div>
     <div class="col-4">
       <div class="p-code-snippet">
-        <input class="p-code-snippet__input deploy-command__field" value="{{ context.entity.id }}"
+        <input class="p-code-snippet__input deploy-command__field" value="juju deploy {{ context.entity.id }}"
           readonly="readonly">
         <button class="p-code-snippet__action">Copy to clipboard</button>
       </div>


### PR DESCRIPTION
## Done

Add ‘juju deploy’ to copy snippet in entity header

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/ntp/32
- Observe the copy snippet in the header says `juju deploy cs:ntp-32`

## Details

Fixes #190 
