### PR TITLE
Add spacing to “Why use Juju” on index

### DIFF
--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -184,7 +184,7 @@
       </div>
     </div>
 
-  <div class="p-strip is-bordered">
+  <div class="p-strip">
     <div class="row">
       <div class="col-12">
         <h2>Why use Juju?</h2>
@@ -198,6 +198,8 @@
         <img src="{{ static_url('img/home/why-use-juju-diagram-right.svg') }}" />
       </div>
     </div>
+  </div>
+  <div class="p-strip is-shallow is-bordered">
     <div class="row">
       <div class="col-8">
         <p>Whether it involves <a href="{{ url_for('jaasai.kubernetes') }}">deep learning</a>, <a href="{{ url_for('jaasai.containers') }}">container orchestration</a>, <a href="{{ url_for('jaasai.big_data') }}">real-time big data</a> or <a href="{{ url_for('jaasai.openstack') }}">stream processing</a>, big software needs operations to be open source and automated.</p>


### PR DESCRIPTION
## Done

Add spacing to “Why use Juju” on index

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Scroll to "Why use Juju" 
- Verify sufficient spacing under large images

## Details

Fixes #198