### PR TITLE
Use the CachedSession from canonicalwebteam.http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ env[23]/
 # Project specific ignores
 static/js/modules/*.js
 static/js/dist/*.js
+.webcache

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black==19.3b0
+canonicalwebteam.http==1.0.1
 feedparser==5.2.1
 Flask-Testing==0.7.1
 Flask==1.0.2
@@ -9,7 +10,6 @@ Markdown==3.1
 prometheus_client==0.6.0
 prometheus-flask-exporter==0.7.1
 raven[flask]==6.10.0
-requests-cache==0.4.13
 statsd==3.3.0
 talisker==0.14.2
 theblues==0.5.1

--- a/webapp/jaasai/views.py
+++ b/webapp/jaasai/views.py
@@ -1,4 +1,3 @@
-import datetime
 import feedparser
 import os
 import canonicalwebteam.http

--- a/webapp/jaasai/views.py
+++ b/webapp/jaasai/views.py
@@ -1,7 +1,7 @@
 import datetime
 import feedparser
 import os
-import requests_cache
+import canonicalwebteam.http
 from flask import (
     Blueprint,
     current_app,
@@ -19,12 +19,7 @@ jaasai = Blueprint(
     "jaasai", __name__, template_folder="/templates", static_folder="/static"
 )
 
-cached_session = requests_cache.CachedSession(
-    name="hour-cache",
-    expire_after=datetime.timedelta(hours=1),
-    backend="memory",
-    old_data_on_error=True,
-)
+cached_session = canonicalwebteam.http.CachedSession()
 
 
 @jaasai.route("/")
@@ -124,8 +119,7 @@ def support():
 @jaasai.route("/blog/feed")
 def blog_feed():
     feed_url = "https://admin.insights.ubuntu.com/tag/juju/feed"
-    # Timeout after 3 seconds if there is no response.
-    response = cached_session.get(feed_url, timeout=3)
+    response = cached_session.get(feed_url)
     feed = feedparser.parse(response.text)
     response = None
     if feed.bozo == 1:


### PR DESCRIPTION
## Done

- Use the CachedSession as provided by https://github.com/canonical-web-and-design/http/.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/blog/feed
- The page should take a few seconds
- Refresh. It should be very quick.

## Details

- Fixes: #180.
