### PR TITLE
Fix search strings

### DIFF
--- a/templates/shared/search-panel.html
+++ b/templates/shared/search-panel.html
@@ -56,15 +56,15 @@
         <div class="p-search-panel__sidebar">
           <h4 class="p-search-panel__heading">Popular searches</h4>
           <ul class="p-list">
-            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search') }}?q=openstack">openstack</a></li>
-            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search') }}?q=ceph">ceph</a></li>
-            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search') }}?q=mysql">mysql</a></li>
-            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search') }}?q=analytics">analytics</a></li>
-            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search') }}?q=spark">spark</a></li>
-            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search') }}?q=nginx">nginx</a></li>
-            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search') }}?q=redis">redis</a></li>
-            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search') }}?q=jenkins">jenkins</a></li>
-            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search') }}?q=logstash">logstash</a></li>
+            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search', q='openstack') }}">openstack</a></li>
+            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search', q='ceph') }}">ceph</a></li>
+            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search', q='mysql') }}">mysql</a></li>
+            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search', q='analytics') }}">analytics</a></li>
+            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search', q='spark') }}">spark</a></li>
+            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search', q='nginx') }}">nginx</a></li>
+            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search', q='redis') }}">redis</a></li>
+            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search', q='jenkins') }}">jenkins</a></li>
+            <li class="p-search-panel__list-item"><a href="{{ url_for('jaasstore.search', q='logstash') }}">logstash</a></li>
           </ul>
         </div>
         <div class="p-search-panel__footer">
@@ -73,35 +73,35 @@
               <strong>Categories:</strong>
             </li>
             <li class="p-inline-list__item">
-              <a href="{{ url_for('jaasstore.search') }}?tags=openstack">openstack
+              <a href="{{ url_for('jaasstore.search', tags='openstack') }}">openstack
               </a>
             </li>
             <li class="p-inline-list__item">
-              <a href="{{ url_for('jaasstore.search') }}?tags=applications">applications
+              <a href="{{ url_for('jaasstore.search', tags='applications') }}">applications
               </a>
             </li>
             <li class="p-inline-list__item">
-              <a href="{{ url_for('jaasstore.search') }}?tags=databases">databases
+              <a href="{{ url_for('jaasstore.search', tags='databases') }}">databases
               </a>
             </li>
             <li class="p-inline-list__item">
-              <a href="{{ url_for('jaasstore.search') }}?tags=app-servers">app-servers
+              <a href="{{ url_for('jaasstore.search', tags='app-servers') }}">app-servers
               </a>
             </li>
             <li class="p-inline-list__item">
-              <a href="{{ url_for('jaasstore.search') }}?tags=file-servers">file-servers
+              <a href="{{ url_for('jaasstore.search', tags='file-servers') }}">file-servers
               </a>
             </li>
             <li class="p-inline-list__item">
-              <a href="{{ url_for('jaasstore.search') }}?tags=monitoring">monitoring
+              <a href="{{ url_for('jaasstore.search', tags='monitoring') }}">monitoring
               </a>
             </li>
             <li class="p-inline-list__item">
-              <a href="{{ url_for('jaasstore.search') }}?tags=misc">misc
+              <a href="{{ url_for('jaasstore.search', tags='misc') }}">misc
               </a>
             </li>
             <li class="p-inline-list__item">
-              <a href="{{ url_for('jaasstore.search') }}?tags=ops">ops
+              <a href="{{ url_for('jaasstore.search', tags='ops') }}">ops
               </a>
             </li>
           </ul>

--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -65,19 +65,19 @@
   <div class="row">
     <div class="col-12 prefix-1 suffix-1 u-align--center">
       <ul class="p-inline-list">
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='databases') }}">databases</a></li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='app-servers') }}">app-servers</a></li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='file-servers') }}">file-servers</a></li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='monitoring') }}">monitoring</a></li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='ops') }}">ops</a></li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='openstack') }}">openstack</a></li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='applications') }}">applications</a></li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='misc') }}">misc</a></li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='network') }}">network</a></li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='analytics') }}">analytics</a></li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='apache') }}">apache</a></li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='security') }}">security</a></li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='storage') }}">storage</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='databases') }}">databases</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='app-servers') }}">app-servers</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='file-servers') }}">file-servers</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='monitoring') }}">monitoring</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='ops') }}">ops</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='openstack') }}">openstack</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='applications') }}">applications</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='misc') }}">misc</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='network') }}">network</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='analytics') }}">analytics</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='apache') }}">apache</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='security') }}">security</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', q='storage') }}">storage</a></li>
       </ul>
     </div>
   </div>
@@ -204,7 +204,7 @@
   <div class="row">
     <div class="col-12">
       <p>
-        <a href="{{ url_for('jaasstore.search', text='ops') }}">View all operations&nbsp;&rsaquo;</a>
+        <a href="{{ url_for('jaasstore.search', q='ops') }}">View all operations&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>
@@ -294,7 +294,7 @@
   <div class="row">
     <div class="col-12">
       <p>
-        <a href="{{ url_for('jaasstore.search', text='analytics') }}">View all analytics&nbsp;&rsaquo;</a>
+        <a href="{{ url_for('jaasstore.search', q='analytics') }}">View all analytics&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>
@@ -388,7 +388,7 @@
   <div class="row">
     <div class="col-12">
       <p>
-        <a href="{{ url_for('jaasstore.search', text='databases') }}">View all databases&nbsp;&rsaquo;</a>
+        <a href="{{ url_for('jaasstore.search', q='databases') }}">View all databases&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Some search URLs were using the old params.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open /store
- Click on a category, e.g. databases. The results should be limited to that term.
- Click in the search box and then click on one of the "Popular searches". It should return relevant results.
