### PR TITLE
Improve entity filter URLs

### DIFF
--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -55,13 +55,13 @@
       <nav class="p-tabs">
         <ul class="p-tabs__list entity-search-selector" role="tablist">
           <li class="p-tabs__item" role="button">
-            <a href="#_" class="p-tabs__link" tabindex="0" role="button" {% if context.current_type == None %}aria-selected="true"{% endif %} data-type="all">All</a>
+            <a href="{{ context.type_urls.all }}" class="p-tabs__link" tabindex="0" role="button" {% if context.current_type == None %}aria-selected="true"{% endif %} data-type="all">All</a>
           </li>
           <li class="p-tabs__item" role="button">
-            <a href="#_" class="p-tabs__link" tabindex="-1" role="button" {% if context.current_type == 'charm' %}aria-selected="true"{% endif %} data-type="charm">Charms</a>
+            <a href="{{ context.type_urls.charms }}" class="p-tabs__link" tabindex="-1" role="button" {% if context.current_type == 'charm' %}aria-selected="true"{% endif %} data-type="charm">Charms</a>
           </li>
           <li class="p-tabs__item" role="button">
-            <a href="#_" class="p-tabs__link" tabindex="-1" role="button" {% if context.current_type == 'bundle' %}aria-selected="true"{% endif %} data-type="bundle">Bundles</a>
+            <a href="{{ context.type_urls.bundles }}" class="p-tabs__link" tabindex="-1" role="button" {% if context.current_type == 'bundle' %}aria-selected="true"{% endif %} data-type="bundle">Bundles</a>
           </li>
         </ul>
       </nav>
@@ -220,7 +220,7 @@
       })
       // No need to change the url if the filter value is already selected.
       if (value !== queries[type]) {
-        if ((type === 'series' || type === 'type') && value === 'all') {
+        if (type === 'series' && value === 'all') {
           delete queries[type];
         } else {
           queries[type] = value;
@@ -233,16 +233,6 @@
       .addEventListener('change', e => _searchChangeFilter('sort', e.target.value));
     document.querySelector('.js-series-select')
       .addEventListener('change', e => _searchChangeFilter('series', e.target.value));
-    document
-      .querySelectorAll('.entity-search-selector li')
-      .forEach(ele => ele.addEventListener('click', e => _searchChangeFilter('type', e.target.dataset.type)));
-    document
-      .querySelectorAll('.p-tabs__link')
-      .forEach(ele => ele.addEventListener('click', e => {
-        e.preventDefault();
-      }));
-
-
   </script>
 {% else %}
   <div class="p-strip">

--- a/tests/store/test_views.py
+++ b/tests/store/test_views.py
@@ -50,6 +50,46 @@ class StoreViews(TestCase):
             mock_search_entities.call_args_list[1], call("k8s", owner="wombat")
         )
 
+    @patch("webapp.store.models.search_entities")
+    def test_search_type_urls(self, mock_search_entities):
+        mock_search_entities.return_value = {
+            "recommended": [{}, {}],
+            "community": [{}, {}],
+        }
+        response = self.client.get(
+            url_for("jaasstore.search", q="k8s", tags="ops", sort="-name")
+        )
+        self.assertEqual(response.status_code, 200)
+        context = self.get_context_variable("context")
+        self.assertEqual(
+            context["type_urls"],
+            {
+                "all": "/search?q=k8s&tags=ops&sort=-name",
+                "bundles": "/search?type=bundle&q=k8s&tags=ops&sort=-name",
+                "charms": "/search?type=charm&q=k8s&tags=ops&sort=-name",
+            },
+        )
+
+    @patch("webapp.store.models.search_entities")
+    def test_search_type_urls_updates_existing(self, mock_search_entities):
+        mock_search_entities.return_value = {
+            "recommended": [{}, {}],
+            "community": [{}, {}],
+        }
+        response = self.client.get(
+            url_for("jaasstore.search", q="k8s", type="bundles")
+        )
+        self.assertEqual(response.status_code, 200)
+        context = self.get_context_variable("context")
+        self.assertEqual(
+            context["type_urls"],
+            {
+                "all": "/search?q=k8s",
+                "bundles": "/search?type=bundle&q=k8s",
+                "charms": "/search?type=charm&q=k8s",
+            },
+        )
+
     @patch("theblues.charmstore.CharmStore.list")
     def test_user_details(self, mock_list):
         mock_list.return_value = user_entities_data

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, abort, request, render_template, Response
+from flask import Blueprint, abort, request, render_template, Response, url_for
 from jujubundlelib import references
 
 from webapp.experts import get_experts
@@ -53,12 +53,29 @@ def search():
             results = models.search_entities(
                 reference.name, owner=reference.user
             )
+    query_params = {}
+    # Recreate the filter params without the type filter. This can then be used
+    # to create new type filter URLS.
+    for param in request.args.items():
+        if param[0] != "type":
+            query_params[param[0]] = param[1]
     return render_template(
         "store/search.html",
         context={
             "current_series": series,
             "current_sort": sort,
             "current_type": entity_type,
+            # Generate the filter URLs here so that when the filter
+            # links are clicked they maintain the other active filters.
+            "type_urls": {
+                "all": url_for("jaasstore.search", **query_params),
+                "bundles": url_for(
+                    "jaasstore.search", type="bundle", **query_params
+                ),
+                "charms": url_for(
+                    "jaasstore.search", type="charm", **query_params
+                ),
+            },
             "results": results,
             "results_count": len(results["recommended"])
             + len(results["community"]),


### PR DESCRIPTION
## Done

- Generate entity filter URLs in the view.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Do a search.
- Change some filters.
- Now switch between All/Charms/Bundles.
- You should get new results that maintain the other filters you selected.

## Details

- Fixes: #185.
