### PR TITLE
Update margins on homepage promos

### DIFF
--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -52,7 +52,7 @@
     </div>
   </div>
 
-  <div class="p-strip is-bordered homepage-hero-promos">
+  <div class="p-strip is-bordered homepage-hero-promos u-no-margin--top">
     <div class="row">
       <div class="u-equal-height">
         <div class="col-4 has-strap">
@@ -68,7 +68,7 @@
           <p><a href="{{ external_urls.gui }}" class="p-button--neutral" style="margin-top:5px">Start a new model</a></p>
         </div>
 
-        <div class="col-4">
+        <div class="col-4 u-no-margin--bottom">
           <h5 class="u-no-padding--top">JAAS is Juju as a service</h5>
           <p>Managed Juju infrastructure, hosted by Canonical, the makers of Ubuntu.</p>
           <div class="p-card u-align--center">
@@ -76,7 +76,6 @@
           </div>
           <a href="{{ url_for('jaasai.jaas') }}" class="p-button--neutral" style="margin-top:-6px">About JAAS</a>
         </div>
-
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

Update margins on homepage promos

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check homepage promos on homepage across breakpoints

Fixes #200
