### PR TITLE
Add bottom margin to series tags in entity header

### DIFF
--- a/static/sass/custom/_search-results.scss
+++ b/static/sass/custom/_search-results.scss
@@ -133,3 +133,9 @@
     color: $color-mid-dark;
   }
 }
+
+@media (max-width: $breakpoint-medium) {
+  .series-tags {
+    margin-bottom: 1rem;
+  }
+}

--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -48,13 +48,15 @@
         {% endif %}
       </ul>
       {% if context.entity.series %}
-      Supports:
-        {% for supported_release in context.entity.series %}
-          <span class="series-tag series-tag--{{ supported_release }}">
-            {{ supported_release }}
-          </span>
-        {% endfor %}
-      {% endif %}
+      <div class="series-tags">
+        Supports:
+          {% for supported_release in context.entity.series %}
+            <span class="series-tag series-tag--{{ supported_release }}">
+              {{ supported_release }}
+            </span>
+          {% endfor %}
+        {% endif %}
+      </div>
     </div>
     <div class="col-4">
       <div class="p-code-snippet">


### PR DESCRIPTION
## Done

Add bottom margin to series tags in entity header

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/apache2/26
- Verify sufficent bottom margin on series tags

## Details

Fixes #189

## Screenshots

<img width="699" alt="Screenshot 2019-04-30 at 12 01 11" src="https://user-images.githubusercontent.com/505570/56957652-c395d900-6b3f-11e9-9bf7-5a89983973f0.png">

