### PR TITLE
Fix broken charm icons in search results

### DIFF
--- a/templates/store/_search_row.html
+++ b/templates/store/_search_row.html
@@ -1,24 +1,24 @@
 <td class="u-hide--small u-vertically-center">
   <ul class="p-inline-list u-no-margin--bottom">
     {% if entity.services %}
-    {% for name, charm in entity.services.items() %}
+    {% for name, entity in entity.services.items() %}
     <li class="p-inline-list__item">
-      <a href="/{{ charm.url }}">
+      <a href="/{{ entity.url }}">
         <span class="p-tooltip p-tooltip--top-center" aria-describedby="tp-cntr">
           {% if outerloop.index > 20 %}
-          {% if charm.icon %}
-          <img data-icon="{{ charm.icon }}" class="entity-icon" src="{{ STATIC_URL }}img/icons/default-charm.svg"
-            alt="{{ charm.display_name }} icon" width="24" />
+          {% if entity.icon %}
+          <img data-icon="{{ entity.icon }}" class="entity-icon" src="https://assets.ubuntu.com/v1/d64591a6-default-charm.svg"
+            alt="{{ entity.display_name }} icon" width="24" />
           {% else %}
-          <img src="{{ STATIC_URL }}img/icons/default-charm.svg" class="entity-icon" alt="{{ charm.display_name }} icon"
+          <img src="https://assets.ubuntu.com/v1/d64591a6-default-charm.svg" class="entity-icon" alt="{{ entity.display_name }} icon"
             width="24" />
           {% endif %}
         </span>
         {% else %}
         {% endif %}
-        <img src="{% if charm.icon %}{{ charm.icon }}{% else %}{{ STATIC_URL }}img/icons/default-charm.svg{% endif %}"
-          class="entity-icon" alt="{{ charm.display_name }} icon" width="24" />
-        <span class="p-tooltip__message" role="tooltip">{{ charm.display_name }}</span>
+        <img src="{% if entity.icon %}{{ entity.icon }}{% else %}https://assets.ubuntu.com/v1/d64591a6-default-charm.svg{% endif %}"
+          class="entity-icon" alt="{{ entity.display_name }} icon" width="24" />
+        <span class="p-tooltip__message" role="tooltip">{{ entity.display_name }}</span>
       </a>
     </li>
     {% endfor %}
@@ -28,15 +28,15 @@
         <span class="p-tooltip p-tooltip--top-center" aria-describedby="tp-cntr">
           {% if outerloop.index > 20 %}
           {% if entity.icon %}
-          <img data-icon="{{ entity.icon }}" class="entity-icon" src="{{ STATIC_URL }}img/icons/default-charm.svg"
+          <img class="entity-icon" src="{% if entity.icon %}{{ entity.icon }}{% else %}https://assets.ubuntu.com/v1/d64591a6-default-charm.svg{% endif %}"
             alt="{{ entity.display_name }} icon" width="24" />
           {% else %}
-          <img src="{{ STATIC_URL }}img/icons/default-charm.svg" class="entity-icon"
+          <img src="https://assets.ubuntu.com/v1/d64591a6-default-charm.svg" class="entity-icon"
             alt="{{ entity.display_name }} icon" width="24" />
           {% endif %}
           {% else %}
           <img
-            src="{% if entity.icon %}{{ entity.icon }}{% else %}{{ STATIC_URL }}img/icons/default-charm.svg{% endif %}"
+            src="{% if entity.icon %}{{ entity.icon }}{% else %}https://assets.ubuntu.com/v1/d64591a6-default-charm.svg{% endif %}"
             class="entity-icon" alt="{{ entity.display_name }} icon" width="24" />
           {% endif %}
           <span class="p-tooltip__message" role="tooltip">{{ entity.display_name }}</span>

--- a/templates/store/bundle-details.html
+++ b/templates/store/bundle-details.html
@@ -81,7 +81,7 @@
                 {% else %}
                   <div class="p-accordion__tab">
                 {% endif %}
-                  <img src="{% if v.icon %}{{ v.icon }}{% else %}{{ STATIC_URL }}img/icons/default-charm.svg{% endif %}"
+                  <img src="{% if v.icon %}{{ v.icon }}{% else %}https://assets.ubuntu.com/v1/d64591a6-default-charm.svg{% endif %}"
                   alt="{{ d }}" width="30" height="30" />
                   <span class="p-accordion__title">
                     {{ v.display_name }}


### PR DESCRIPTION
## Done

- Replaced 'charm' reference with 'entity' reference
- Fix broken charm icons in search results
- Replaced broken default charm link with asset from the assets server

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open https://staging.jaas.ai/search?type=charm
- Scroll all the way to the bottom and verify all charm icons load correctly

## Details

Fixes #193
