### PR TITLE
Fix link to /containers from store

### DIFF
--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -215,7 +215,7 @@
     <div class="col-6">
       <h2>Container management</h2>
       <p>Juju makes it easy to deploy container management solutions by provisioning, installing and configuring all the systems in the cluster.</p>
-      <p><a href="{{ url_for('jaasai.containers') }} class="p-button--neutral">View bundles</a></p>
+      <p><a href="{{ url_for('jaasai.containers') }}" class="p-button--neutral">View bundles</a></p>
     </div>
     <div class="col-6">
         <img src="{{ static_url('img/store/kubernetes-promo.png') }}" alt="Kubernetes promo pictogram">


### PR DESCRIPTION
## Done

Fix link to /containers from store

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/store
- Scroll to 'Container management'
- Click on 'Bundles' link
- Link should not 404

## Details

Fix #219
