### PR TITLE
Fix search filters

### DIFF
--- a/tests/store/test_views.py
+++ b/tests/store/test_views.py
@@ -47,7 +47,16 @@ class StoreViews(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(mock_search_entities.call_count, 2)
         self.assertEqual(
-            mock_search_entities.call_args_list[1], call("k8s", owner="wombat")
+            mock_search_entities.call_args_list[1],
+            call(
+                "k8s",
+                owner="wombat",
+                entity_type=None,
+                tags=None,
+                sort=None,
+                series=None,
+                promulgated_only=False,
+            ),
         )
 
     @patch("webapp.store.models.search_entities")

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -51,7 +51,13 @@ def search():
         reference = models.get_reference(query)
         if reference is not None:
             results = models.search_entities(
-                reference.name, owner=reference.user
+                reference.name,
+                owner=reference.user,
+                entity_type=entity_type,
+                tags=tags,
+                sort=sort,
+                series=series,
+                promulgated_only=False,
             )
     query_params = {}
     # Recreate the filter params without the type filter. This can then be used


### PR DESCRIPTION
## Done

- Include the filters in the second search.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open /search?q=kubernetes&series=centos7
- There should be no search results (because the filters are being applied).

## Details

- Fixes: #229.
