### PR TITLE
Fix series wrapping on search results

### DIFF
--- a/static/sass/custom/_search-results.scss
+++ b/static/sass/custom/_search-results.scss
@@ -14,6 +14,7 @@
     th,
     td {
       flex: 1;
+      flex-wrap: wrap;
 
       &:first-child {
         flex: 0.5;


### PR DESCRIPTION
## Done

- Correctly wrap the series tags on the search results.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open /search?q=nova+hyperv
- The series should wrap within their column.

## Details

- Fixes: #223.
