### PR TITLE
Home bundle name wrapping

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -146,7 +146,7 @@ $color-experts-highlight: #e95420;
 // icon list
 .icon-list {
   &__link {
-      display: flex;
+    display: flex;
   }
 
   &__image {
@@ -156,8 +156,8 @@ $color-experts-highlight: #e95420;
   &__title {
     align-items: center;
     display: flex;
-    padding-left: 1rem;
     flex: 1;
+    padding-left: 1rem;
   }
 }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -145,12 +145,20 @@ $color-experts-highlight: #e95420;
 
 // icon list
 .icon-list {
+  &__item {
+    margin-bottom: 0.25rem;
+  }
+
   &__link {
     display: flex;
   }
 
   &__image {
     flex: 0 0 52px;
+
+    img {
+      vertical-align: middle;
+    }
   }
 
   &__title {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -145,12 +145,19 @@ $color-experts-highlight: #e95420;
 
 // icon list
 .icon-list {
+  &__link {
+      display: flex;
+  }
+
+  &__image {
+    flex: 0 0 52px;
+  }
+
   &__title {
-    bottom: 1rem;
-    display: inline-block;
-    margin-top: 0;
+    align-items: center;
+    display: flex;
     padding-left: 1rem;
-    position: relative;
+    flex: 1;
   }
 }
 

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -111,24 +111,30 @@
               <p><b>Bundles</b> are collections of charms that link services together, so you can deploy whole chunks of infrastructure in one go.</p>
               <ul class="p-list icon-list">
                 <li class="p-list__item">
-                  <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='openstack-base') }}">
-                    <img src="https://assets.ubuntu.com/v1/2e50c6c7-openstack-base.svg" alt="Openstack Base icon" />
+                  <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='openstack-base') }}" class="icon-list__link">
+                    <span class="icon-list__image">
+                      <img src="https://assets.ubuntu.com/v1/2e50c6c7-openstack-base.svg" alt="Openstack Base icon" />
+                    </span>
                     <span class="icon-list__title">
                       OpenStack Base&nbsp;&rsaquo;
                     </span>
                   </a>
                 </li>
                 <li class="p-list__item">
-                  <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}">
-                    <img src="https://assets.ubuntu.com/v1/3181c7b2-canonical-kubernetes.svg" alt="Canonical Kubernetes icon" />
+                  <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}" class="icon-list__link">
+                    <span class="icon-list__image">
+                      <img src="https://assets.ubuntu.com/v1/3181c7b2-canonical-kubernetes.svg" alt="Canonical Kubernetes icon" />
+                    </span>
                     <span class="icon-list__title">
                       Canonical Kubernetes&nbsp;&rsaquo;
                     </span>
                   </a>
                 </li>
                 <li class="p-list__item">
-                  <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='hadoop-spark') }}">
-                    <img src="https://assets.ubuntu.com/v1/40c3bc89-hadoop-spark.svg" alt="Hadoop Spark icon" />
+                  <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='hadoop-spark') }}" class="icon-list__link">
+                    <span class="icon-list__image">
+                      <img src="https://assets.ubuntu.com/v1/40c3bc89-hadoop-spark.svg" alt="Hadoop Spark icon" />
+                    </span>
                     <span class="icon-list__title">
                       Hadoop Spark&nbsp;&rsaquo;
                     </span>
@@ -140,24 +146,30 @@
               <p><b>Charms</b> contain scripts that simplify the deployment and management of a service.</p>
               <ul class="p-list icon-list">
                 <li class="p-list__item">
-                  <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='postgresql') }}">
-                    <img width="52" src="https://assets.ubuntu.com/v1/a854c8a7-postgresql-circle.svg" alt="Postgresql icon" />
+                  <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='postgresql') }}" class="icon-list__link">
+                    <span class="icon-list__image">
+                      <img width="52" src="https://assets.ubuntu.com/v1/a854c8a7-postgresql-circle.svg" alt="Postgresql icon" />
+                    </span>
                     <span class="icon-list__title">
                       Postgresql&nbsp;&rsaquo;
                     </span>
                   </a>
                 </li>
                 <li class="p-list__item">
-                  <a href="{{ url_for('jaasstore.user_entity', username='prometheus-charmers', charm_or_bundle_name='prometheus') }}">
-                    <img width="52" src="https://assets.ubuntu.com/v1/804a5808-prometheus-circle.svg" alt="Prometheus" />
+                  <a href="{{ url_for('jaasstore.user_entity', username='prometheus-charmers', charm_or_bundle_name='prometheus') }}" class="icon-list__link">
+                    <span class="icon-list__image">
+                      <img width="52" src="https://assets.ubuntu.com/v1/804a5808-prometheus-circle.svg" alt="Prometheus" />
+                    </span>
                     <span class="icon-list__title">
                       Prometheus&nbsp;&rsaquo;
                     </span>
                   </a>
                 </li>
                 <li class="p-list__item">
-                  <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='elasticsearch') }}">
-                    <img width="52" src="https://assets.ubuntu.com/v1/9842fcf6-elasticsearch-icon.svg" alt="Elasticsearch" />
+                  <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='elasticsearch') }}" class="icon-list__link">
+                    <span class="icon-list__image">
+                      <img width="52" src="https://assets.ubuntu.com/v1/9842fcf6-elasticsearch-icon.svg" alt="Elasticsearch" />
+                    </span>
                     <span class="icon-list__title">
                       Elasticsearch&nbsp;&rsaquo;
                     </span>

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -110,7 +110,7 @@
             <div class="step-block__section">
               <p><b>Bundles</b> are collections of charms that link services together, so you can deploy whole chunks of infrastructure in one go.</p>
               <ul class="p-list icon-list">
-                <li class="p-list__item">
+                <li class="p-list__item icon-list__item">
                   <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='openstack-base') }}" class="icon-list__link">
                     <span class="icon-list__image">
                       <img src="https://assets.ubuntu.com/v1/2e50c6c7-openstack-base.svg" alt="Openstack Base icon" />
@@ -120,7 +120,7 @@
                     </span>
                   </a>
                 </li>
-                <li class="p-list__item">
+                <li class="p-list__item icon-list__item">
                   <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}" class="icon-list__link">
                     <span class="icon-list__image">
                       <img src="https://assets.ubuntu.com/v1/3181c7b2-canonical-kubernetes.svg" alt="Canonical Kubernetes icon" />
@@ -130,7 +130,7 @@
                     </span>
                   </a>
                 </li>
-                <li class="p-list__item">
+                <li class="p-list__item icon-list__item">
                   <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='hadoop-spark') }}" class="icon-list__link">
                     <span class="icon-list__image">
                       <img src="https://assets.ubuntu.com/v1/40c3bc89-hadoop-spark.svg" alt="Hadoop Spark icon" />
@@ -145,7 +145,7 @@
             <div class="step-block__section">
               <p><b>Charms</b> contain scripts that simplify the deployment and management of a service.</p>
               <ul class="p-list icon-list">
-                <li class="p-list__item">
+                <li class="p-list__item icon-list__item">
                   <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='postgresql') }}" class="icon-list__link">
                     <span class="icon-list__image">
                       <img width="52" src="https://assets.ubuntu.com/v1/a854c8a7-postgresql-circle.svg" alt="Postgresql icon" />
@@ -155,7 +155,7 @@
                     </span>
                   </a>
                 </li>
-                <li class="p-list__item">
+                <li class="p-list__item icon-list__item">
                   <a href="{{ url_for('jaasstore.user_entity', username='prometheus-charmers', charm_or_bundle_name='prometheus') }}" class="icon-list__link">
                     <span class="icon-list__image">
                       <img width="52" src="https://assets.ubuntu.com/v1/804a5808-prometheus-circle.svg" alt="Prometheus" />
@@ -165,7 +165,7 @@
                     </span>
                   </a>
                 </li>
-                <li class="p-list__item">
+                <li class="p-list__item icon-list__item">
                   <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='elasticsearch') }}" class="icon-list__link">
                     <span class="icon-list__image">
                       <img width="52" src="https://assets.ubuntu.com/v1/9842fcf6-elasticsearch-icon.svg" alt="Elasticsearch" />


### PR DESCRIPTION
## Done

- Wrap the bundle names nicely on the homepage.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Scroll down to the Deploy section
- Resize your browser down to mobile
- The bundle and charm titles should wrap nicely and stay vertically centred at every browser size.

## Details

- Fixes: #236.
