### PR TITLE
Update the Container strip on the store.

### DIFF
--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -211,14 +211,16 @@
 </div>
 
 <div class="p-strip--light is-shallow">
-  <div class="row">
-    <div class="col-6">
-      <h2>Container management</h2>
-      <p>Juju makes it easy to deploy container management solutions by provisioning, installing and configuring all the systems in the cluster.</p>
-      <p><a href="{{ url_for('jaasai.containers') }}" class="p-button--neutral">View bundles</a></p>
+  <div class="row u-equal-height entity-cards">
+    <div class="col-5 u-vertically-center">
+      <div>
+        <h2>Container management</h2>
+        <p>Juju makes it easy to deploy container management solutions by provisioning, installing and configuring all the systems in the cluster.</p>
+        <p><a href="{{ url_for('jaasai.containers') }}" class="p-button--neutral">View bundles</a></p>
+      </div>
     </div>
-    <div class="col-6">
-        <img src="https://assets.ubuntu.com/v1/eebb613b-kubernetes-promo.png" alt="Kubernetes promo pictogram">
+    <div class="col-7 u-hide--small u-align--right">
+      <img src="https://assets.ubuntu.com/v1/86a111b8-CDK+bundle.svg" alt="Kubernetes promo pictogram" width="350">
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Update the "Container management" strip image and layout in the store.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open /store
- Scroll to the "Container management" section
- it should have the image like the design: https://user-images.githubusercontent.com/9105999/57071836-9417d580-6cd3-11e9-9abb-33356d812455.png

## Details

- Fixes: #227.
