### PR TITLE
Dedupe models

### DIFF
--- a/templates/store/_search_row.html
+++ b/templates/store/_search_row.html
@@ -11,8 +11,8 @@
 
 <td class="u-hide--small u-vertically-center">
   <ul class="p-inline-list u-no-margin--bottom">
-    {% if entity.services %}
-      {% for name, entity in entity.services.items() %}
+    {% if entity.applications %}
+      {% for name, entity in entity.applications.items() %}
         {{ icon(entity) }}
       {% endfor %}
     {% else %}

--- a/templates/store/bundle-details.html
+++ b/templates/store/bundle-details.html
@@ -40,16 +40,16 @@
         </div>
       {% endif %}
 
-      {% if context.entity.bundle_data.Meta['common-info'] %}
+      {% if context.entity.homepage or context.entity.bugs_url %}
         <div class="p-card">
           <h4 class="p-card__title">Contribute</h4>
-          {% if context.entity.bundle_data.Meta['common-info']['homepage'] %}
-            <p><a href="{{ context.entity.bundle_data.Meta['common-info']['homepage'] }}">
+          {% if context.entity.homepage %}
+            <p><a href="{{ context.entity.homepage }}">
               Project homepage
             </a></p>
           {% endif %}
-          {% if context.entity.bundle_data.Meta['common-info']['bugs-url'] %}
-            <p><a href="{{ context.entity.bundle_data.Meta['common-info']['bugs-url'] }}">
+          {% if context.entity.bugs_url %}
+            <p><a href="{{ context.entity.bugs_url }}">
               Submit a bug
             </a></p>
           {% endif %}
@@ -75,7 +75,7 @@
         <aside class="p-accordion" role="tablist" aria-multiselect="true">
           <ul class="p-accordion__list">
             <li class="p-accordion__group">
-              {% for d,v in context.entity.services.items() %}
+              {% for d,v in context.entity.applications.items() %}
                 {% if v.Options %}
                   <button class="p-accordion__tab" id="charm-config-{{ d  }}-tab" role="tab" aria-controls="#charm-config-{{ d  }}" aria-expanded="false">
                 {% else %}

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -44,10 +44,10 @@
           {% endfor %}
         </ul>
       {% endif %}
-      {% if context.entity.charm_data['Meta']['charm-metadata']['Tags'] %}
+      {% if context.entity.tags %}
         <ul class="p-inline-list">
           <li class="p-inline-list__item"><strong>Tags:</strong></li>
-          {% for tag in context.entity.charm_data['Meta']['charm-metadata']['Tags'] %}
+          {% for tag in context.entity.tags %}
             <li class="p-inline-list__item"><a href="{{ url_for('jaasstore.search', tags=tag) }}">{{ tag }}&nbsp;&rsaquo;</a></li>
           {% endfor %}
         </ul>

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -20,34 +20,31 @@ class TestStoreModels(unittest.TestCase):
         self.assertEqual(len(results["community"]), 0)
         self.assertEqual(len(results["recommended"]), 0)
 
-    def test_parse_charm_data(self):
-        charm = models._parse_charm_data(charm_data)
+    def test_charm(self):
+        charm = models.Charm(charm_data)
         self.assertEqual(
-            charm["archive_url"],
+            charm.archive_url,
             "https://api.jujucharms.com/v5/apache2-26/archive",
         )
         self.assertEqual(
-            charm["bugs_url"], "https://bugs.launchpad.net/apache2-charm"
+            charm.bugs_url, "https://bugs.launchpad.net/apache2-charm"
         )
-        self.assertIsNone(charm["bzr_url"])
-        self.assertEqual(charm["card_id"], "apache2-26")
+        self.assertEqual(charm.card_id, "apache2-26")
         self.assertEqual(
-            charm["channels"], [{"Channel": "stable", "Current": True}]
+            charm.channels, [{"Channel": "stable", "Current": True}]
         )
         self.assertTrue(
-            "The Apache Software Foundation's goal" in charm["description"]
+            "The Apache Software Foundation's goal" in charm.description
         )
-        self.assertEqual(charm["display_name"], "apache2")
+        self.assertEqual(charm.display_name, "apache2")
+        self.assertEqual(charm.homepage, "https://launchpad.net/apache2-charm")
         self.assertEqual(
-            charm["homepage"], "https://launchpad.net/apache2-charm"
+            charm.icon, "https://api.jujucharms.com/v5/apache2-26/icon.svg"
         )
+        self.assertEqual(charm.id, "cs:apache2-26")
+        self.assertTrue(charm.is_charm)
         self.assertEqual(
-            charm["icon"], "https://api.jujucharms.com/v5/apache2-26/icon.svg"
-        )
-        self.assertEqual(charm["id"], "cs:apache2-26")
-        self.assertTrue(charm["is_charm"])
-        self.assertEqual(
-            charm["latest_revision"],
+            charm.latest_revision,
             {
                 "full_id": "cs:precise/apache2-27",
                 "id": 27,
@@ -55,7 +52,7 @@ class TestStoreModels(unittest.TestCase):
             },
         )
         self.assertEqual(
-            charm["options"].get("apt-key-id"),
+            charm.options.get("apt-key-id"),
             {
                 "Type": "string",
                 "Description": (
@@ -67,10 +64,10 @@ class TestStoreModels(unittest.TestCase):
                 "Default": "",
             },
         )
-        self.assertEqual(charm["owner"], "apache2-charmers")
-        self.assertIsNone(charm["promulgated"])
+        self.assertEqual(charm.owner, "apache2-charmers")
+        self.assertIsNone(charm.promulgated)
         self.assertEqual(
-            charm["provides"].get("apache-website"),
+            charm.provides.get("apache-website"),
             {
                 "Name": "apache-website",
                 "Role": "provider",
@@ -81,7 +78,7 @@ class TestStoreModels(unittest.TestCase):
             },
         )
         self.assertEqual(
-            charm["requires"].get("balancer"),
+            charm.requires.get("balancer"),
             {
                 "Name": "balancer",
                 "Role": "requirer",
@@ -91,20 +88,20 @@ class TestStoreModels(unittest.TestCase):
                 "Scope": "global",
             },
         )
-        self.assertEqual(charm["resources"], {})
-        self.assertTrue(len(charm["revision_list"]) > 0)
-        self.assertEqual(charm["revision_list"][0], "cs:precise/apache2-27")
-        self.assertEqual(charm["revision_number"], 26)
-        self.assertEqual(len(charm["revisions"]), 10)
-        self.assertEqual(charm["series"], ["xenial", "trusty", "bionic"])
-        self.assertEqual(charm["tags"], ["app-servers"])
-        self.assertEqual(charm["url"], "apache2/26")
+        self.assertEqual(charm.resources, {})
+        self.assertTrue(len(charm.revision_list) > 0)
+        self.assertEqual(charm.revision_list[0], "cs:precise/apache2-27")
+        self.assertEqual(charm.revision_number, 26)
+        self.assertEqual(len(charm.revisions), 10)
+        self.assertEqual(charm.series, ["xenial", "trusty", "bionic"])
+        self.assertEqual(charm.tags, ["app-servers"])
+        self.assertEqual(charm.url, "apache2/26")
 
-    def test_parse_charm_data_terms(self):
+    def test_charm_terms(self):
         charm_data["Meta"]["terms"] = ["special-term/99", "another-term"]
-        charm = models._parse_charm_data(charm_data)
+        charm = models.Charm(charm_data)
         self.assertEqual(
-            charm["term_ids"],
+            charm.term_ids,
             [
                 {
                     "id": "special-term/99",
@@ -119,39 +116,42 @@ class TestStoreModels(unittest.TestCase):
             ],
         )
 
-    def test_parse_charm_data_supported(self):
+    def test_charm_supported(self):
         charm_data["Meta"]["extra-info"]["supported"] = "true"
         charm_data["Meta"]["extra-info"]["price"] = "99"
         charm_data["Meta"]["extra-info"][
             "description"
         ] = "Great ol' charm\nthis one"
-        charm = models._parse_charm_data(charm_data)
-        self.assertTrue(charm["supported"])
-        self.assertEqual(charm["supported_price"], "99")
+        charm = models.Charm(charm_data)
+        self.assertTrue(charm.supported)
+        self.assertEqual(charm.supported_price, "99")
         self.assertEqual(
-            charm["supported_description"],
+            charm.supported_description,
             "<p>Great ol' charm<br />\nthis one</p>",
         )
 
-    def test_parse_bundle_data(self):
-        bundle = models._parse_bundle_data(bundle_data)
+    def test_bundle(self):
+        bundle = models.Bundle(bundle_data)
         self.assertEqual(
-            bundle["archive_url"],
+            bundle.archive_url,
             (
                 "https://api.jujucharms.com/v5/bundle/"
                 "canonical-kubernetes-466/archive"
             ),
         )
         self.assertEqual(
-            bundle["bundle_visulisation"],
+            bundle.bundle_visulisation,
             (
                 "https://api.jujucharms.com/v5/bundle/canonical-kubernetes-466"
                 "/diagram.svg"
             ),
         )
-        self.assertEqual(bundle["card_id"], "bundle/canonical-kubernetes-466")
         self.assertEqual(
-            bundle["channels"],
+            bundle.bugs_url, "https://bugs.launchpad.net/charmed-kubernetes"
+        )
+        self.assertEqual(bundle.card_id, "bundle/canonical-kubernetes-466")
+        self.assertEqual(
+            bundle.channels,
             [
                 {"Channel": "stable", "Current": False},
                 {"Channel": "candidate", "Current": False},
@@ -160,40 +160,43 @@ class TestStoreModels(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            bundle["description"],
+            bundle.description,
             "<p>A highly-available, production-grade Kubernetes cluster.</p>",
         )
         self.assertEqual(
-            bundle["display_name"], "The Charmed Distribution of Kubernetes"
+            bundle.display_name, "The Charmed Distribution of Kubernetes"
         )
-        self.assertEqual(bundle["id"], "cs:bundle/canonical-kubernetes-466")
-        self.assertFalse(bundle["is_charm"])
         self.assertEqual(
-            bundle["latest_revision"],
+            bundle.homepage, "https://www.ubuntu.com/kubernetes/docs"
+        )
+        self.assertEqual(bundle.id, "cs:bundle/canonical-kubernetes-466")
+        self.assertFalse(bundle.is_charm)
+        self.assertEqual(
+            bundle.latest_revision,
             {
                 "id": 530,
                 "full_id": "cs:bundle/canonical-kubernetes-530",
                 "url": "canonical-kubernetes/bundle/530",
             },
         )
-        self.assertEqual(bundle["owner"], "containers")
-        self.assertIsNone(bundle["promulgated"])
-        self.assertEqual(bundle["revision_number"], 466)
-        self.assertEqual(bundle["series"], ["bionic"])
-        self.assertIsNone(bundle["tags"])
-        self.assertEqual(bundle["units"], 10)
-        self.assertEqual(bundle["url"], "canonical-kubernetes/bundle/466")
+        self.assertEqual(bundle.owner, "containers")
+        self.assertIsNone(bundle.promulgated)
+        self.assertEqual(bundle.revision_number, 466)
+        self.assertEqual(bundle.series, ["bionic"])
+        self.assertIsNone(bundle.tags)
+        self.assertEqual(bundle.units, 10)
+        self.assertEqual(bundle.url, "canonical-kubernetes/bundle/466")
 
-    def test_parse_bundle_data_supported(self):
+    def test_bundle_supported(self):
         bundle_data["Meta"]["extra-info"]["supported"] = "true"
         bundle_data["Meta"]["extra-info"]["price"] = "99"
         bundle_data["Meta"]["extra-info"][
             "description"
         ] = "Great ol' bundle\nthis one"
-        bundle = models._parse_bundle_data(bundle_data)
-        self.assertTrue(bundle["supported"])
-        self.assertEqual(bundle["supported_price"], "99")
+        bundle = models.Bundle(bundle_data)
+        self.assertTrue(bundle.supported)
+        self.assertEqual(bundle.supported_price, "99")
         self.assertEqual(
-            bundle["supported_description"],
+            bundle.supported_description,
             "<p>Great ol' bundle<br />\nthis one</p>",
         )

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -123,11 +123,11 @@ def details(charm_or_bundle_name, series_or_version=None, version=None):
 
     if entity:
         template = "store/{}-details.html".format(
-            "charm" if entity["is_charm"] else "bundle"
+            "charm" if entity.is_charm else "bundle"
         )
         return render_template(
             template,
-            context={"entity": entity, "expert": get_experts(entity["owner"])},
+            context={"entity": entity, "expert": get_experts(entity.owner)},
         )
     else:
         return abort(404, "Entity not found {}".format(charm_or_bundle_name))


### PR DESCRIPTION
## Done

- Transform charm and bundle definitions into classes.
- Remove duplication of attributes.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Have a poke around pages that show charms/bundles. Everything should be unchanged.