### PR TITLE
Align search rows to the top

### DIFF
--- a/static/sass/custom/_entities.scss
+++ b/static/sass/custom/_entities.scss
@@ -17,6 +17,14 @@
 }
 
 .entity {
+  &__header {
+    @media (max-width: $breakpoint-medium) {
+      .series-tags {
+        margin-bottom: 1rem;
+      }
+    }
+  }
+
   &__title-wrap {
     align-items: center;
     display: flex;

--- a/static/sass/custom/_search-results.scss
+++ b/static/sass/custom/_search-results.scss
@@ -22,6 +22,11 @@
         flex: 0.5;
       }
     }
+
+    &__icons,
+    &__series {
+      padding-top: 0.75rem;
+    }
   }
 }
 
@@ -188,11 +193,5 @@
   a {
     font-size: 0.875rem;
     color: $color-mid-dark;
-  }
-}
-
-@media (max-width: $breakpoint-medium) {
-  .series-tags {
-    margin-bottom: 1rem;
   }
 }

--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -1,5 +1,5 @@
 <div class="p-strip--light is-bordered is-shallow">
-  <header class="row">
+  <header class="row entity__header">
     <div class="col-8">
       <div class="entity__title-wrap">
         {% if context.entity.icon %}

--- a/templates/store/_search_row.html
+++ b/templates/store/_search_row.html
@@ -9,7 +9,7 @@
   </li>
 {%- endmacro %}
 
-<td class="u-hide--small u-vertically-center">
+<td class="u-hide--small search-results-table__icons">
   <ul class="p-inline-list u-no-margin--bottom">
     {% if entity.services %}
       {% for name, entity in entity.services.items() %}
@@ -21,7 +21,7 @@
   </ul>
 </td>
 
-<td class="u-vertically-center">
+<td>
   <div>
     <a href="/{{ entity.url }}">
       <h4 class="search-results__entity-name u-no-margin--bottom">{{ entity.display_name }}</h4>
@@ -36,7 +36,7 @@
   </div>
 </td>
 
-<td class="u-vertically-center">
+<td class="search-results-table__series">
   {% if entity.series %}
     {% for series in entity.series %}
     <a href="{{ current_url_with_query(series=series) }}" class="series-tag series-tag--{{ series }}">
@@ -46,7 +46,7 @@
   {% endif %}
 </td>
 
-<td class="u-vertically-center">
+<td>
   {% if entity.owner %}
     <a href="{{ url_for('jaasstore.user_details', username=entity.owner) }}">{{ entity.owner }}</a>
   {% else %}


### PR DESCRIPTION
## Done

- Top align the info in the search results table to match the new designs.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open /search
- The content should be top aligned in the cells

## Details

- Fixes: #242.
