### PR TITLE
Add bundle icons

### DIFF
--- a/static/js/src/search-icons.js
+++ b/static/js/src/search-icons.js
@@ -1,0 +1,8 @@
+// Delegate error events to load default icons.
+document.querySelectorAll('.search-results-table').forEach(function(table) {
+  table.addEventListener('error', function(evt) {
+    if (evt.target.classList.contains('search-results__icon')) {
+      evt.target.src = 'https://assets.ubuntu.com/v1/d64591a6-default-charm.svg';
+    }
+  }, true);
+});

--- a/static/sass/custom/_search-results.scss
+++ b/static/sass/custom/_search-results.scss
@@ -54,8 +54,8 @@
     .search-results__icon {
       &:first-child {
         // Set a background to handle overlapping transparent icons.
-        background-color: #fff;
-        box-shadow: 0 0 0 0.04rem #fff;
+        background-color: $color-x-light;
+        box-shadow: 0 0 0 0.04rem $color-x-light;
         position: relative;
       }
 

--- a/static/sass/custom/_search-results.scss
+++ b/static/sass/custom/_search-results.scss
@@ -1,6 +1,8 @@
 @import 'vanilla-framework/scss/settings_spacing';
 
 .search-results {
+  $icon-size: 24px;
+
   &__entity-name {
     line-height: 1.5rem;
     font-size: 1rem;
@@ -27,6 +29,29 @@
     &__series {
       padding-top: 0.75rem;
     }
+  }
+
+  &__bundle-icon {
+    $padding: 2px;
+    border-radius: (($padding * 2) + $icon-size) / 2;
+    border: 1px solid $color-mid-light;
+    display: inline-block;
+    padding: $padding 5px + $padding $padding $padding;
+
+    @at-root a#{&} {
+      color: $color-mid-dark;
+    }
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  &__icon {
+    border-radius: $icon-size / 2;
+    max-height: $icon-size;
+    max-width: $icon-size;
+    vertical-align: bottom;
   }
 }
 
@@ -151,10 +176,6 @@
       margin-top: -0.5rem;
     }
   }
-}
-
-.entity-icon {
-  border-radius: 50%;
 }
 
 @media (min-width: $breakpoint-small) {

--- a/static/sass/custom/_search-results.scss
+++ b/static/sass/custom/_search-results.scss
@@ -22,6 +22,7 @@
 
       &:first-child {
         flex: 0.25;
+        min-width: 5rem;
         padding-right: 0;
       }
     }
@@ -66,6 +67,7 @@
 
   &__icon {
     border-radius: $icon-size / 2;
+    display: inline-block;
     height: $icon-size;
     width: $icon-size;
     vertical-align: bottom;

--- a/static/sass/custom/_search-results.scss
+++ b/static/sass/custom/_search-results.scss
@@ -1,7 +1,7 @@
 @import 'vanilla-framework/scss/settings_spacing';
 
 .search-results {
-  $icon-size: 24px;
+  $icon-size: 1.5rem;
 
   &__entity-name {
     line-height: 1.5rem;
@@ -21,7 +21,8 @@
       flex-wrap: wrap;
 
       &:first-child {
-        flex: 0.5;
+        flex: 0.25;
+        padding-right: 0;
       }
     }
 
@@ -32,11 +33,14 @@
   }
 
   &__bundle-icon {
-    $padding: 2px;
+    $padding: 0.12rem;
     border-radius: (($padding * 2) + $icon-size) / 2;
-    border: 1px solid $color-mid-light;
+    border: 0.06rem solid $color-mid-light;
     display: inline-block;
-    padding: $padding 5px + $padding $padding $padding;
+    font-size: 0.875rem;
+    padding: $padding 0.3rem + $padding $padding $padding;
+    position: relative;
+    top: -0.12rem;
 
     @at-root a#{&} {
       color: $color-mid-dark;
@@ -45,12 +49,25 @@
     &:hover {
       text-decoration: none;
     }
+
+    .search-results__icon {
+      &:first-child {
+        // Set a background to handle overlapping transparent icons.
+        background-color: #fff;
+        box-shadow: 0 0 0 0.04rem #fff;
+        position: relative;
+      }
+
+      &:nth-child(2) {
+        margin-left: -1.2rem;
+      }
+    }
   }
 
   &__icon {
     border-radius: $icon-size / 2;
-    max-height: $icon-size;
-    max-width: $icon-size;
+    height: $icon-size;
+    width: $icon-size;
     vertical-align: bottom;
   }
 }

--- a/templates/store/_search_row.html
+++ b/templates/store/_search_row.html
@@ -1,8 +1,16 @@
-<td class="u-hide--small">
+<td class="search-results-table__icons u-hide--small">
   <a href="/{{ entity.url }}" class="u-no-link-underline {% if entity.applications %}search-results__bundle-icon{% endif %}">
-    <img src="{{ entity.icon }}" class="search-results__icon" alt="" width="24" />
-    {% if entity.applications %}
-      +{{ entity.applications|count - 1 }}
+    {% if entity.icons %}
+      {% for icon in entity.icons %}
+        <img src="{{ icon }}" class="search-results__icon" alt="" />
+      {% endfor %}
+      {% set extra_count = entity.applications|count - 2 %}
+      {% if extra_count < 0 %}
+        {% set extra_count = 0 %}
+      {% endif %}
+      +{{ extra_count }}
+    {% else %}
+      <img src="{{ entity.icon }}" class="search-results__icon" alt="" />
     {% endif %}
   </a>
 </td>

--- a/templates/store/_search_row.html
+++ b/templates/store/_search_row.html
@@ -1,24 +1,10 @@
-{% macro icon(entity) -%}
-  <li class="p-inline-list__item">
-    <a href="/{{ entity.url }}" class="u-no-link-underline">
-      <span class="p-tooltip p-tooltip--top-center" aria-describedby="tp-cntr">
-        <img src="{{ entity.icon }}" class="entity-icon" alt="{{ entity.display_name }} icon" width="24" />
-        <span class="p-tooltip__message" role="tooltip">{{ entity.display_name }}</span>
-      </span>
-    </a>
-  </li>
-{%- endmacro %}
-
-<td class="u-hide--small search-results-table__icons">
-  <ul class="p-inline-list u-no-margin--bottom">
+<td class="u-hide--small">
+  <a href="/{{ entity.url }}" class="u-no-link-underline {% if entity.applications %}search-results__bundle-icon{% endif %}">
+    <img src="{{ entity.icon }}" class="search-results__icon" alt="" width="24" />
     {% if entity.applications %}
-      {% for name, entity in entity.applications.items() %}
-        {{ icon(entity) }}
-      {% endfor %}
-    {% else %}
-      {{ icon(entity) }}
+      +{{ entity.applications|count - 1 }}
     {% endif %}
-  </ul>
+  </a>
 </td>
 
 <td>

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -191,14 +191,7 @@
    {% endif %}
 
   <script src="{{ static_url('js/dist/search-filters.min.js') }}"></script>
-  <script type="text/javascript">
-    // Delegate error events to load default icons.
-    document.querySelector('.search-results-table').addEventListener('error', function(evt) {
-      if (evt.target.classList.contains('search-results__icon')) {
-        evt.target.src = 'https://assets.ubuntu.com/v1/d64591a6-default-charm.svg';
-      }
-    }, true);
-  </script>
+  <script src="{{ static_url('js/dist/search-icons.min.js') }}"></script>
 {% else %}
   <div class="p-strip">
     <div class="row">

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -191,6 +191,14 @@
    {% endif %}
 
   <script src="{{ static_url('js/dist/search-filters.min.js') }}"></script>
+  <script type="text/javascript">
+    // Delegate error events to load default icons.
+    document.querySelector('.search-results-table').addEventListener('error', function(evt) {
+      if (evt.target.classList.contains('search-results__icon')) {
+        evt.target.src = 'https://assets.ubuntu.com/v1/d64591a6-default-charm.svg';
+      }
+    }, true);
+  </script>
 {% else %}
   <div class="p-strip">
     <div class="row">

--- a/templates/store/user-details.html
+++ b/templates/store/user-details.html
@@ -94,4 +94,6 @@
    </div>
  {% endif %}
 
+ <script src="{{ static_url('js/dist/search-icons.min.js') }}"></script>
+
 {% endblock %}

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -203,33 +203,69 @@ class TestStoreModels(unittest.TestCase):
             "<p>Great ol' bundle<br />\nthis one</p>",
         )
 
-    def test_bundle_icon(self):
+    def test_bundle_icons(self):
         bundle = models.Bundle(bundle_data)
         self.assertEqual(
-            bundle.icon,
-            (
-                "https://api.jujucharms.com/v5/~containers/"
-                "kubernetes-master-636/icon.svg"
-            ),
+            bundle.icons,
+            [
+                (
+                    "https://api.jujucharms.com/v5/~containers/"
+                    "kubernetes-master-636/icon.svg"
+                ),
+                (
+                    "https://api.jujucharms.com/v5/~containers/"
+                    "kubernetes-worker-502/icon.svg"
+                ),
+            ],
         )
 
-    def test_bundle_icon_no_match(self):
+    def test_bundle_icons_no_match(self):
         data = copy.deepcopy(bundle_data)
         data["Id"] = "cs:nothing-here-123"
         bundle = models.Bundle(data)
         self.assertEqual(
-            bundle.icon,
-            "https://api.jujucharms.com/v5/~containers/easyrsa-231/icon.svg",
+            bundle.icons,
+            [
+                (
+                    "https://api.jujucharms.com/v5/"
+                    "~containers/easyrsa-231/icon.svg"
+                ),
+                "https://api.jujucharms.com/v5/~containers/etcd-411/icon.svg",
+            ],
         )
 
-    def test_bundle_icon_exact_match(self):
+    def test_bundle_icons_exact_match(self):
         data = copy.deepcopy(bundle_data)
         data["Id"] = "~containers/kubeapi-load-balancer-613"
         bundle = models.Bundle(data)
         self.assertEqual(
-            bundle.icon,
-            (
-                "https://api.jujucharms.com/v5/~containers/"
-                "kubeapi-load-balancer-613/icon.svg"
-            ),
+            bundle.icons,
+            [
+                (
+                    "https://api.jujucharms.com/v5/~containers/"
+                    "kubeapi-load-balancer-613/icon.svg"
+                ),
+                (
+                    "https://api.jujucharms.com/v5/~containers/"
+                    "easyrsa-231/icon.svg"
+                ),
+            ],
+        )
+
+    def test_bundle_icons_only_one(self):
+        data = copy.deepcopy(bundle_data)
+        data["Meta"]["bundle-metadata"]["applications"] = {
+            "kubernetes-master": {
+                "Charm": "cs:~containers/kubernetes-master-636"
+            }
+        }
+        bundle = models.Bundle(data)
+        self.assertEqual(
+            bundle.icons,
+            [
+                (
+                    "https://api.jujucharms.com/v5/~containers/"
+                    "kubernetes-master-636/icon.svg"
+                )
+            ],
         )

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -200,3 +200,17 @@ class TestStoreModels(unittest.TestCase):
             bundle.supported_description,
             "<p>Great ol' bundle<br />\nthis one</p>",
         )
+
+    def test_bundle_icon(self):
+        bundle = models.Bundle(bundle_data)
+        self.assertEqual(bundle.icon, 'https://api.jujucharms.com/v5/~containers/kubernetes-master-636/icon.svg')
+
+    def test_bundle_icon_no_match(self):
+        bundle_data['Id'] = 'cs:nothing-here-123'
+        bundle = models.Bundle(bundle_data)
+        self.assertEqual(bundle.icon, 'https://api.jujucharms.com/v5/~containers/easyrsa-231/icon.svg')
+
+    def test_bundle_icon_exact_match(self):
+        bundle_data['Id'] = '~containers/kubeapi-load-balancer-613'
+        bundle = models.Bundle(bundle_data)
+        self.assertEqual(bundle.icon, 'https://api.jujucharms.com/v5/~containers/kubeapi-load-balancer-613/icon.svg')

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 from tests.store.testdata import bundle_data, charm_data, search_data
 from unittest.mock import patch
@@ -98,8 +99,9 @@ class TestStoreModels(unittest.TestCase):
         self.assertEqual(charm.url, "apache2/26")
 
     def test_charm_terms(self):
-        charm_data["Meta"]["terms"] = ["special-term/99", "another-term"]
-        charm = models.Charm(charm_data)
+        data = copy.deepcopy(charm_data)
+        data["Meta"]["terms"] = ["special-term/99", "another-term"]
+        charm = models.Charm(data)
         self.assertEqual(
             charm.term_ids,
             [
@@ -117,12 +119,11 @@ class TestStoreModels(unittest.TestCase):
         )
 
     def test_charm_supported(self):
-        charm_data["Meta"]["extra-info"]["supported"] = "true"
-        charm_data["Meta"]["extra-info"]["price"] = "99"
-        charm_data["Meta"]["extra-info"][
-            "description"
-        ] = "Great ol' charm\nthis one"
-        charm = models.Charm(charm_data)
+        data = copy.deepcopy(charm_data)
+        data["Meta"]["extra-info"]["supported"] = "true"
+        data["Meta"]["extra-info"]["price"] = "99"
+        data["Meta"]["extra-info"]["description"] = "Great ol' charm\nthis one"
+        charm = models.Charm(data)
         self.assertTrue(charm.supported)
         self.assertEqual(charm.supported_price, "99")
         self.assertEqual(
@@ -188,12 +189,13 @@ class TestStoreModels(unittest.TestCase):
         self.assertEqual(bundle.url, "canonical-kubernetes/bundle/466")
 
     def test_bundle_supported(self):
-        bundle_data["Meta"]["extra-info"]["supported"] = "true"
-        bundle_data["Meta"]["extra-info"]["price"] = "99"
-        bundle_data["Meta"]["extra-info"][
+        data = copy.deepcopy(bundle_data)
+        data["Meta"]["extra-info"]["supported"] = "true"
+        data["Meta"]["extra-info"]["price"] = "99"
+        data["Meta"]["extra-info"][
             "description"
         ] = "Great ol' bundle\nthis one"
-        bundle = models.Bundle(bundle_data)
+        bundle = models.Bundle(data)
         self.assertTrue(bundle.supported)
         self.assertEqual(bundle.supported_price, "99")
         self.assertEqual(
@@ -203,14 +205,31 @@ class TestStoreModels(unittest.TestCase):
 
     def test_bundle_icon(self):
         bundle = models.Bundle(bundle_data)
-        self.assertEqual(bundle.icon, 'https://api.jujucharms.com/v5/~containers/kubernetes-master-636/icon.svg')
+        self.assertEqual(
+            bundle.icon,
+            (
+                "https://api.jujucharms.com/v5/~containers/"
+                "kubernetes-master-636/icon.svg"
+            ),
+        )
 
     def test_bundle_icon_no_match(self):
-        bundle_data['Id'] = 'cs:nothing-here-123'
-        bundle = models.Bundle(bundle_data)
-        self.assertEqual(bundle.icon, 'https://api.jujucharms.com/v5/~containers/easyrsa-231/icon.svg')
+        data = copy.deepcopy(bundle_data)
+        data["Id"] = "cs:nothing-here-123"
+        bundle = models.Bundle(data)
+        self.assertEqual(
+            bundle.icon,
+            "https://api.jujucharms.com/v5/~containers/easyrsa-231/icon.svg",
+        )
 
     def test_bundle_icon_exact_match(self):
-        bundle_data['Id'] = '~containers/kubeapi-load-balancer-613'
-        bundle = models.Bundle(bundle_data)
-        self.assertEqual(bundle.icon, 'https://api.jujucharms.com/v5/~containers/kubeapi-load-balancer-613/icon.svg')
+        data = copy.deepcopy(bundle_data)
+        data["Id"] = "~containers/kubeapi-load-balancer-613"
+        bundle = models.Bundle(data)
+        self.assertEqual(
+            bundle.icon,
+            (
+                "https://api.jujucharms.com/v5/~containers/"
+                "kubeapi-load-balancer-613/icon.svg"
+            ),
+        )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ module.exports = {
     app: './static/js/src/app.js',
     'blog-feed': './static/js/src/blog-feed.js',
     'search-filters': './static/js/src/search-filters.js',
+    'search-icons': './static/js/src/search-icons.js',
   },
   mode: process.env.ENVIRONMENT === "devel" ? "development" : "production",
   output: {


### PR DESCRIPTION
## Done

- Choose an icon for the bundle based on the name of the bundle and charms.
- Load a default icon if an icon 404s.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open /search?type=bundle
- Look through the list of icons and see if the chosen icon makes sense in most cases.
- The bundle icons should look like the one here: https://app.zeplin.io/project/5c5871a14e1897355935afb1/screen/5c6bc4e840eb10462ed01ed7

## Details
- Fixes: #253.