### PR TITLE
Remove squircles

### DIFF
--- a/static/sass/custom/_entities.scss
+++ b/static/sass/custom/_entities.scss
@@ -49,4 +49,8 @@
       text-transform: capitalize;
     }
   }
+
+  &__charm-icon {
+    border-radius: 50%;
+  }
 }

--- a/static/sass/custom/_search-panel.scss
+++ b/static/sass/custom/_search-panel.scss
@@ -18,6 +18,10 @@
     max-width: 64.875rem;
   }
 
+  &__featured-image {
+    border-radius: 50%;
+  }
+
   @at-root {
     .p-search-panel__close {
       position: absolute;

--- a/templates/shared/search-panel.html
+++ b/templates/shared/search-panel.html
@@ -9,47 +9,47 @@
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}"
             class="p-search-panel__featured-link">
             <img src="{{ external_urls.charmstore }}~containers/kubernetes-master/icon.svg" alt=""
-              class="search-panel__featured-image" />
+              class="p-search-panel__featured-image" />
             <p class="p-search-panel__featured-name">kubernetes</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='elasticsearch') }}"
             class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}elasticsearch/icon.svg" alt="" class="search-panel__featured-image" />
+            <img src="{{ external_urls.charmstore }}elasticsearch/icon.svg" alt="" class="p-search-panel__featured-image" />
             <p class="p-search-panel__featured-name">elasticsearch</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='kafka') }}" class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}kafka/icon.svg" alt="" class="search-panel__featured-image" />
+            <img src="{{ external_urls.charmstore }}kafka/icon.svg" alt="" class="p-search-panel__featured-image" />
             <p class="p-search-panel__featured-name">kafka</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='zookeeper') }}"
             class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}zookeeper/icon.svg" alt="" class="search-panel__featured-image" />
+            <img src="{{ external_urls.charmstore }}zookeeper/icon.svg" alt="" class="p-search-panel__featured-image" />
             <p class="p-search-panel__featured-name">zookeeper</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='ceph') }}" class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}ceph/icon.svg" alt="" class="search-panel__featured-image" />
+            <img src="{{ external_urls.charmstore }}ceph/icon.svg" alt="" class="p-search-panel__featured-image" />
             <p class="p-search-panel__featured-name">ceph</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='cassandra') }}"
             class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}cassandra/icon.svg" alt="" class="search-panel__featured-image" />
+            <img src="{{ external_urls.charmstore }}cassandra/icon.svg" alt="" class="p-search-panel__featured-image" />
             <p class="p-search-panel__featured-name">cassandra</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='percona-cluster') }}"
             class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}percona-cluster/icon.svg" alt="" class="search-panel__featured-image" />
+            <img src="{{ external_urls.charmstore }}percona-cluster/icon.svg" alt="" class="p-search-panel__featured-image" />
             <p class="p-search-panel__featured-name">percona-cluster</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='glance') }}" class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}glance/icon.svg" alt="" class="search-panel__featured-image" />
+            <img src="{{ external_urls.charmstore }}glance/icon.svg" alt="" class="p-search-panel__featured-image" />
             <p class="p-search-panel__featured-name">glance</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='mariadb') }}" class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}mariadb/icon.svg" alt="" class="search-panel__featured-image" />
+            <img src="{{ external_urls.charmstore }}mariadb/icon.svg" alt="" class="p-search-panel__featured-image" />
             <p class="p-search-panel__featured-name">mariadb</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='spark') }}" class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}spark/icon.svg" alt="" class="search-panel__featured-image" />
+            <img src="{{ external_urls.charmstore }}spark/icon.svg" alt="" class="p-search-panel__featured-image" />
             <p class="p-search-panel__featured-name">spark</p>
           </a>
         </div>

--- a/templates/store/bundle-details.html
+++ b/templates/store/bundle-details.html
@@ -81,8 +81,7 @@
                 {% else %}
                   <div class="p-accordion__tab">
                 {% endif %}
-                  <img src="{{ v.icon }}"
-                  alt="{{ d }}" width="30" height="30" />
+                  <img src="{{ v.icon }}" alt="{{ d }}" width="30" height="30" class="entity__charm-icon" />
                   <span class="p-accordion__title">
                     {{ v.display_name }}
                   </span>


### PR DESCRIPTION
## Done

- Display icons as circles on the bundle details page and search dropdown.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open /u/marcoceppi/k8s-plus-nagios/bundle/0
- Check that the charm icons are circles in the "Bundle configuration" section on the right hand side.
- Click in the search box to open the search panel. All icons should be circles.

## Details

- Fixes: #248.
