### PR TITLE
Series labels colours

### DIFF
--- a/static/sass/custom/_series_tags.scss
+++ b/static/sass/custom/_series_tags.scss
@@ -31,6 +31,35 @@ a.series-tag--kubernetes,
   color: $color-kubernetes;
 }
 
+a.series-tag--win2012hvr2,
+.series-tag--win2012hvr2,
+a.series-tag--win2012hv,
+.series-tag--win2012hv,
+a.series-tag--win2012r2,
+.series-tag--win2012r2,
+a.series-tag--win2012,
+.series-tag--win2012,
+a.series-tag--win7,
+.series-tag--win7,
+a.series-tag--win8,
+.series-tag--win8,
+a.series-tag--win81,
+.series-tag--win81,
+a.series-tag--win10,
+.series-tag--win10,
+a.series-tag--win2016,
+.series-tag--win2016,
+a.series-tag--win2016hv,
+.series-tag--win2016hv,
+a.series-tag--win2016nano,
+.series-tag--win2016nano,
+a.series-tag--centos7,
+.series-tag--centos7 {
+    @extend %series-tag;
+    border-color: $color-information;
+    color: $color-information;
+}
+
 .series-tag--None {
   display: none;
 }

--- a/static/sass/custom/_series_tags.scss
+++ b/static/sass/custom/_series_tags.scss
@@ -31,6 +31,9 @@ a.series-tag--kubernetes,
   color: $color-kubernetes;
 }
 
+
+// The list of series can be found here:
+// https://github.com/juju/charmstore/blob/v5/internal/series/series.go#L61
 a.series-tag--win2012hvr2,
 .series-tag--win2012hvr2,
 a.series-tag--win2012hv,


### PR DESCRIPTION
## Done

- Fix series label colours for centos and windows.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open /search?type=charm&series=centos7 and /search?type=charm&series=win2016
- The labels should be dark blue.

## Details

- Fixes: #249.
