### PR TITLE
Fix paragraph spacing

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -8,6 +8,10 @@ $color-navigation-active-bar: #e95420;
 $color-kubernetes: #2e69ea;
 $grid-max-width: 72rem;
 
+// Import cookie-policy. This needs to be before the vanilla imports otherwise
+// this will override other generic styles.
+@import '@canonical/cookie-policy/src/sass/cookie-policy';
+
 // Set the mobile nav breakpoint to handle the large number of nav items.
 @import 'vanilla-framework/scss/settings_breakpoints';
 $breakpoint-navigation-threshold: $breakpoint-large;
@@ -19,9 +23,6 @@ $breakpoint-navigation-threshold: $breakpoint-large;
 
 $cool-grey: $color-brand;
 $mid-grey: $color-mid-light;
-
-// Import cookie-policy
-@import '@canonical/cookie-policy/src/sass/cookie-policy';
 
 // Custom snowflake code for bespoke components
 @import 'custom/row-cli';

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -23,6 +23,7 @@ $mid-grey: $color-mid-light;
 // Import cookie-policy. Just import the bits we need as the proper file
 // includes override for other generic styles.
 @import '@canonical/cookie-policy/src/sass/patterns-notification';
+
 .cookie-policy {
   @include vf-u-off-screen;
   @include vf-b-placeholders;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -8,10 +8,6 @@ $color-navigation-active-bar: #e95420;
 $color-kubernetes: #2e69ea;
 $grid-max-width: 72rem;
 
-// Import cookie-policy. This needs to be before the vanilla imports otherwise
-// this will override other generic styles.
-@import '@canonical/cookie-policy/src/sass/cookie-policy';
-
 // Set the mobile nav breakpoint to handle the large number of nav items.
 @import 'vanilla-framework/scss/settings_breakpoints';
 $breakpoint-navigation-threshold: $breakpoint-large;
@@ -23,6 +19,16 @@ $breakpoint-navigation-threshold: $breakpoint-large;
 
 $cool-grey: $color-brand;
 $mid-grey: $color-mid-light;
+
+// Import cookie-policy. Just import the bits we need as the proper file
+// includes override for other generic styles.
+@import '@canonical/cookie-policy/src/sass/patterns-notification';
+.cookie-policy {
+  @include vf-u-off-screen;
+  @include vf-b-placeholders;
+  @include vf-p-notification;
+  @include cookie-p-notification;
+}
 
 // Custom snowflake code for bespoke components
 @import 'custom/row-cli';


### PR DESCRIPTION
## Done

- Move the cookie policy scss import so that it doesn't override other Vanilla styles.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check that the paragraph spacing is not too small (see the screenshots in #250).

## Details

- Fixes: #250.
- Fixes: #252.