### PR TITLE
Remove rogue underline from charm icons

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -334,3 +334,10 @@ h2 {
     }
   }
 }
+
+// Util to disable link underline on hover
+.u-no-link-underline {
+  &:hover {
+    text-decoration: none;
+  }
+}

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -107,17 +107,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <div class="col-4">
       <ul class="p-inline-list u-no-margin--top">
         <li class="p-inline-list__item">
-            <a href="http://www.facebook.com/ubuntucloud">
+            <a href="http://www.facebook.com/ubuntucloud" class="u-no-link-underline">
               <img width="32" src="https://assets.ubuntu.com/v1/44628f1c-facebook.svg" alt="Facebook icon">
             </a>
         </li>
         <li class="p-inline-list__item">
-          <a href="http://www.twitter.com/ubuntucloud">
+          <a href="http://www.twitter.com/ubuntucloud" class="u-no-link-underline">
             <img width="32" src="https://assets.ubuntu.com/v1/83d8233c-vanilla-twitter.svg" alt="Twitter icon">
           </a>
         </li>
         <li class="p-inline-list__item">
-          <a href="http://youtube.com/jujucharms">
+          <a href="http://youtube.com/jujucharms" class="u-no-link-underline">
             <img width="32" src="https://assets.ubuntu.com/v1/95ed370e-vanilla-youtube.svg" alt="Youtube icon">
           </a>
         </li>

--- a/templates/store/_search_row.html
+++ b/templates/store/_search_row.html
@@ -1,6 +1,6 @@
 {% macro icon(entity) -%}
   <li class="p-inline-list__item">
-    <a href="/{{ entity.url }}">
+    <a href="/{{ entity.url }}" class="u-no-link-underline">
       <span class="p-tooltip p-tooltip--top-center" aria-describedby="tp-cntr">
         <img src="{{ entity.icon }}" class="entity-icon" alt="{{ entity.display_name }} icon" width="24" />
         <span class="p-tooltip__message" role="tooltip">{{ entity.display_name }}</span>


### PR DESCRIPTION
## Done

Remove rogue underline from charm icons

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/search?type=bundle
- Hover over charm icons and verify no weird little underline appears

## Details

Fixes #254
