### PR TITLE
Bump global nav to 2.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@canonical/cookie-policy": "^2.0.1",
-    "@canonical/global-nav": "2.0.6",
+    "@canonical/global-nav": "2.0.8",
     "autoprefixer": "9.5.1",
     "babel-loader": "8.0.5",
     "concurrently": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,9 +731,10 @@
     rollup-plugin-terser "4.0.4"
     vanilla-framework "1.8.1"
 
-"@canonical/global-nav@2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.0.6.tgz#e80abeccf26c6ca64bef2d4a5f6db8a1505870ea"
+"@canonical/global-nav@2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.0.8.tgz#36eafbae0be0a854e953902cd2c6152e574d5ed1"
+  integrity sha512-IM7gOBSB9QMDoo2Bp52KfmmVFzemUrPBeWKKtV0RNFod7Gn1eEZ6QOt98eiLzpPgAWomPCZdAZgV+UQekK3ffQ==
 
 "@types/estree@0.0.39":
   version "0.0.39"


### PR DESCRIPTION
## Done

Bump global nav to 2.0.8

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Bask in those accessibility gains 💪🏻

<img width="520" alt="Screenshot 2019-05-14 at 16 59 43" src="https://user-images.githubusercontent.com/505570/57708725-1e642000-766a-11e9-901b-971ddce4e6d0.png">


