### PR TITLE
Use the default Charmstore API URL

### DIFF
--- a/templates/store/bundle-details.html
+++ b/templates/store/bundle-details.html
@@ -18,7 +18,7 @@
         </div>
       {% endif %}
       <div class="p-card--highlighted">
-        <object type="image/svg+xml" data="{{ context.entity.bundle_visulisation }}"></object>
+        <object type="image/svg+xml" data="{{ context.entity.bundle_visualisation }}"></object>
       </div>
       {% if context.entity.readme %}
         <div class="readme" id="readme">

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -22,13 +22,8 @@ class TestStoreModels(unittest.TestCase):
 
     def test_parse_charm_data(self):
         charm = models._parse_charm_data(charm_data)
-        self.assertEqual(
-            charm["archive_url"],
-            "https://api.jujucharms.com/v5/apache2-26/archive",
-        )
-        self.assertEqual(
-            charm["bugs_url"], "https://bugs.launchpad.net/apache2-charm"
-        )
+        self.assertTrue("archive_url" in charm and charm["archive_url"])
+        self.assertTrue("bugs_url" in charm and charm["bugs_url"])
         self.assertIsNone(charm["bzr_url"])
         self.assertEqual(charm["card_id"], "apache2-26")
         self.assertEqual(
@@ -41,9 +36,7 @@ class TestStoreModels(unittest.TestCase):
         self.assertEqual(
             charm["homepage"], "https://launchpad.net/apache2-charm"
         )
-        self.assertEqual(
-            charm["icon"], "https://api.jujucharms.com/v5/apache2-26/icon.svg"
-        )
+        self.assertTrue("icon" in charm and charm["icon"])
         self.assertEqual(charm["id"], "cs:apache2-26")
         self.assertTrue(charm["is_charm"])
         self.assertEqual(
@@ -135,19 +128,9 @@ class TestStoreModels(unittest.TestCase):
 
     def test_parse_bundle_data(self):
         bundle = models._parse_bundle_data(bundle_data)
-        self.assertEqual(
-            bundle["archive_url"],
-            (
-                "https://api.jujucharms.com/v5/bundle/"
-                "canonical-kubernetes-466/archive"
-            ),
-        )
-        self.assertEqual(
-            bundle["bundle_visulisation"],
-            (
-                "https://api.jujucharms.com/v5/bundle/canonical-kubernetes-466"
-                "/diagram.svg"
-            ),
+        self.assertTrue("archive_url" in bundle and bundle["archive_url"])
+        self.assertTrue(
+            "bundle_visualisation" in bundle and bundle["bundle_visualisation"]
         )
         self.assertEqual(bundle["card_id"], "bundle/canonical-kubernetes-466")
         self.assertEqual(

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -9,7 +9,7 @@ from theblues.errors import EntityNotFound, ServerError
 from theblues.terms import Terms
 
 
-cs = CharmStore("https://api.jujucharms.com/v5")
+cs = CharmStore()
 terms = Terms("https://api.jujucharms.com/terms/")
 
 SEARCH_LIMIT = 400

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -179,7 +179,7 @@ def _parse_bundle_data(bundle_data, include_files=False):
     return {
         "archive_url": cs.archive_url(ref),
         "bundle_data": bundle_data,
-        "bundle_visulisation": getBundleVisualization(ref),
+        "bundle_visualisation": cs.bundle_visualization_url(ref),
         "card_id": ref.path(),
         "channels": meta.get("published", {}).get("Info"),
         # Some bundles don't have descriptions, so first check that the
@@ -318,20 +318,6 @@ def _get_entity_files(ref, manifest=None):
     except EntityNotFound:
         files = {}
     return files
-
-
-def getBundleVisualization(ref, fetch=False):
-    """Get the url for the bundle visualization, or the actual svg.
-        :param ref The reference of the bundle to get the visualization for.
-        :param fetch Whether or not to get the actual svg.
-        :returns the URL or the SVG for the bundle visualisation
-    """
-    if not fetch:
-        return cs.bundle_visualization_url(ref)
-    try:
-        return cs.bundle_visualization(ref)
-    except EntityNotFound:
-        return None
 
 
 def _extract_resources(ref, resources):


### PR DESCRIPTION
## Done
Use the default Charmstore API URL

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check that charm details load
- Check the network tab in inspector is loading from `https://api.jujucharms.com/charmstore/v5/`

