### PR TITLE
Search queries should be more than two characters

### DIFF
--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -194,6 +194,17 @@
   <script src="{{ static_url('js/dist/search-icons.min.js') }}"></script>
 {% else %}
   <div class="p-strip">
+    {% if context.query|length <= 2 %}
+      <div class="row">
+        <div class="col-12">
+          <div class="p-notification--negative">
+            <p class="p-notification__response">
+              <span class="p-notification__status">Error:</span> Your search query needs to be more than two characters.
+            </p>
+          </div>
+        </div>
+      </div>
+    {% endif %}
     <div class="row">
       <div class="col-8">
         <h4>Sorry, your search for <strong>{{ context.query }}</strong> returned 0 results.</h4>


### PR DESCRIPTION
## Done

Search queries should be more than two characters or an error message is displayed in search results.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/search?q=hu
- Verify an error noticiation is displayed

## Details

Fixes #247