### PR TITLE
Fix robots.txt file and serve sitemap filetypes as xml

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -4,4 +4,4 @@ Disallow: /terms/*
 Disallow: /blog/feed
 Disallow: /blog/feed/
 
-Sitemap: /sitemap.xml
+Sitemap: https://jaas.ai/sitemap.xml

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,5 +1,4 @@
 User-agent: *
-Crawl-delay: 10
 
 Disallow: /terms/*
 Disallow: /blog/feed

--- a/webapp/jaasai/views.py
+++ b/webapp/jaasai/views.py
@@ -134,18 +134,21 @@ def static_from_root():
     return send_from_directory(current_app.static_folder, request.path[1:])
 
 
-@jaasai.route("/sitemap.xml")
-def sitemap():
-    xml = render_template("sitemaps/sitemap.xml")
+def set_xml_content_type( path, context ):
+    print(context)
+    xml = render_template(path, context=context)
     response = make_response(xml)
     response.headers['Content-Type'] = 'application/xml'
     return response
 
 
+@jaasai.route("/sitemap.xml")
+def sitemap():
+    return set_xml_content_type("sitemaps/sitemap.xml")
+
+
 @jaasai.route("/sitemap-base.xml")
 def sitemap_base():
-    xml = render_template(
-        "sitemaps/sitemap-base.xml",
         context={
             "pages": [
                 "jaasai.big_data",
@@ -166,11 +169,8 @@ def sitemap_base():
                 "jaasstore.store",
                 "jaasstore.search",
             ]
-        },
-    )
-    response = make_response(xml)
-    response.headers['Content-Type'] = 'application/xml'
-    return response
+        }
+        return set_xml_content_type("sitemaps/sitemap-base.xml", context)
 
 
 @jaasai.route("/sitemap-store.xml")
@@ -180,12 +180,7 @@ def sitemap_store():
     for entity in results:
         ref = references.Reference.from_string(entity.get("Id"))
         entities.append(ref.jujucharms_id())
-    xml = render_template(
-        "sitemaps/sitemap-store.xml", context={"entities": entities}
-    )
-    response = make_response(xml)
-    response.headers['Content-Type'] = 'application/xml'
-    return response
+    return set_xml_content_type("sitemaps/sitemap-store.xml", {"entities": entities})
 
 
 @jaasai.route("/_status/check")

--- a/webapp/jaasai/views.py
+++ b/webapp/jaasai/views.py
@@ -5,6 +5,7 @@ from flask import (
     Blueprint,
     current_app,
     jsonify,
+    make_response,
     render_template,
     request,
     send_from_directory,
@@ -135,12 +136,15 @@ def static_from_root():
 
 @jaasai.route("/sitemap.xml")
 def sitemap():
-    return render_template("sitemaps/sitemap.xml")
+    xml = render_template("sitemaps/sitemap.xml")
+    response = make_response(xml)
+    response.headers['Content-Type'] = 'application/xml'
+    return response
 
 
 @jaasai.route("/sitemap-base.xml")
 def sitemap_base():
-    return render_template(
+    xml = render_template(
         "sitemaps/sitemap-base.xml",
         context={
             "pages": [
@@ -164,6 +168,9 @@ def sitemap_base():
             ]
         },
     )
+    response = make_response(xml)
+    response.headers['Content-Type'] = 'application/xml'
+    return response
 
 
 @jaasai.route("/sitemap-store.xml")
@@ -173,9 +180,12 @@ def sitemap_store():
     for entity in results:
         ref = references.Reference.from_string(entity.get("Id"))
         entities.append(ref.jujucharms_id())
-    return render_template(
+    xml = render_template(
         "sitemaps/sitemap-store.xml", context={"entities": entities}
     )
+    response = make_response(xml)
+    response.headers['Content-Type'] = 'application/xml'
+    return response
 
 
 @jaasai.route("/_status/check")

--- a/webapp/jaasai/views.py
+++ b/webapp/jaasai/views.py
@@ -134,11 +134,11 @@ def static_from_root():
     return send_from_directory(current_app.static_folder, request.path[1:])
 
 
-def set_xml_content_type( path, context ):
+def set_xml_content_type(path, context={}):
     print(context)
     xml = render_template(path, context=context)
     response = make_response(xml)
-    response.headers['Content-Type'] = 'application/xml'
+    response.headers["Content-Type"] = "application/xml"
     return response
 
 
@@ -149,28 +149,28 @@ def sitemap():
 
 @jaasai.route("/sitemap-base.xml")
 def sitemap_base():
-        context={
-            "pages": [
-                "jaasai.big_data",
-                "jaasai.community_cards",
-                "jaasai.community_partners",
-                "jaasai.community",
-                "jaasai.containers",
-                "jaasai.experts_spicule",
-                "jaasai.experts_tengu",
-                "jaasai.experts_thanks",
-                "jaasai.experts",
-                "jaasai.getting_started",
-                "jaasai.how_it_works",
-                "jaasai.jaas",
-                "jaasai.kubernetes",
-                "jaasai.openstack",
-                "jaasai.support",
-                "jaasstore.store",
-                "jaasstore.search",
-            ]
-        }
-        return set_xml_content_type("sitemaps/sitemap-base.xml", context)
+    context = {
+        "pages": [
+            "jaasai.big_data",
+            "jaasai.community_cards",
+            "jaasai.community_partners",
+            "jaasai.community",
+            "jaasai.containers",
+            "jaasai.experts_spicule",
+            "jaasai.experts_tengu",
+            "jaasai.experts_thanks",
+            "jaasai.experts",
+            "jaasai.getting_started",
+            "jaasai.how_it_works",
+            "jaasai.jaas",
+            "jaasai.kubernetes",
+            "jaasai.openstack",
+            "jaasai.support",
+            "jaasstore.store",
+            "jaasstore.search",
+        ]
+    }
+    return set_xml_content_type("sitemaps/sitemap-base.xml", context)
 
 
 @jaasai.route("/sitemap-store.xml")
@@ -180,7 +180,9 @@ def sitemap_store():
     for entity in results:
         ref = references.Reference.from_string(entity.get("Id"))
         entities.append(ref.jujucharms_id())
-    return set_xml_content_type("sitemaps/sitemap-store.xml", {"entities": entities})
+    return set_xml_content_type(
+        "sitemaps/sitemap-store.xml", {"entities": entities}
+    )
 
 
 @jaasai.route("/_status/check")


### PR DESCRIPTION
## Done

- Make sitemap URL absolute
- Set response headers on sitemaps to be xml
- Remove Crawl-delay directive

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/sitemap.xml - should display as XML
- Open http://0.0.0.0:8029/sitemap-base.xml - should display as XML and list all pages
- Open http://0.0.0.0:8029/sitemap-store.xml - should display as XML and list all pages

## Details

Fixes #271 
