### PR TITLE
Use default charmstore

### DIFF
--- a/templates/store/bundle-details.html
+++ b/templates/store/bundle-details.html
@@ -18,7 +18,7 @@
         </div>
       {% endif %}
       <div class="p-card--highlighted">
-        <object type="image/svg+xml" data="{{ context.entity.bundle_visulisation }}"></object>
+        <object type="image/svg+xml" data="{{ context.entity.bundle_visualisation }}"></object>
       </div>
       {% if context.entity.readme %}
         <div class="readme" id="readme">

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -25,7 +25,7 @@ class TestStoreModels(unittest.TestCase):
         charm = models.Charm(charm_data)
         self.assertEqual(
             charm.archive_url,
-            "https://api.jujucharms.com/v5/apache2-26/archive",
+            "https://api.jujucharms.com/charmstore/v5/apache2-26/archive",
         )
         self.assertEqual(
             charm.bugs_url, "https://bugs.launchpad.net/apache2-charm"
@@ -40,7 +40,8 @@ class TestStoreModels(unittest.TestCase):
         self.assertEqual(charm.display_name, "apache2")
         self.assertEqual(charm.homepage, "https://launchpad.net/apache2-charm")
         self.assertEqual(
-            charm.icon, "https://api.jujucharms.com/v5/apache2-26/icon.svg"
+            charm.icon,
+            "https://api.jujucharms.com/charmstore/v5/apache2-26/icon.svg",
         )
         self.assertEqual(charm.id, "cs:apache2-26")
         self.assertTrue(charm.is_charm)
@@ -136,15 +137,15 @@ class TestStoreModels(unittest.TestCase):
         self.assertEqual(
             bundle.archive_url,
             (
-                "https://api.jujucharms.com/v5/bundle/"
+                "https://api.jujucharms.com/charmstore/v5/bundle/"
                 "canonical-kubernetes-466/archive"
             ),
         )
         self.assertEqual(
-            bundle.bundle_visulisation,
+            bundle.bundle_visualisation,
             (
-                "https://api.jujucharms.com/v5/bundle/canonical-kubernetes-466"
-                "/diagram.svg"
+                "https://api.jujucharms.com/charmstore/v5/bundle/"
+                "canonical-kubernetes-466/diagram.svg"
             ),
         )
         self.assertEqual(
@@ -209,11 +210,11 @@ class TestStoreModels(unittest.TestCase):
             bundle.icons,
             [
                 (
-                    "https://api.jujucharms.com/v5/~containers/"
+                    "https://api.jujucharms.com/charmstore/v5/~containers/"
                     "kubernetes-master-636/icon.svg"
                 ),
                 (
-                    "https://api.jujucharms.com/v5/~containers/"
+                    "https://api.jujucharms.com/charmstore/v5/~containers/"
                     "kubernetes-worker-502/icon.svg"
                 ),
             ],
@@ -227,10 +228,13 @@ class TestStoreModels(unittest.TestCase):
             bundle.icons,
             [
                 (
-                    "https://api.jujucharms.com/v5/"
+                    "https://api.jujucharms.com/charmstore/v5/"
                     "~containers/easyrsa-231/icon.svg"
                 ),
-                "https://api.jujucharms.com/v5/~containers/etcd-411/icon.svg",
+                (
+                    "https://api.jujucharms.com/charmstore/v5/~containers/"
+                    "etcd-411/icon.svg"
+                ),
             ],
         )
 
@@ -242,11 +246,11 @@ class TestStoreModels(unittest.TestCase):
             bundle.icons,
             [
                 (
-                    "https://api.jujucharms.com/v5/~containers/"
+                    "https://api.jujucharms.com/charmstore/v5/~containers/"
                     "kubeapi-load-balancer-613/icon.svg"
                 ),
                 (
-                    "https://api.jujucharms.com/v5/~containers/"
+                    "https://api.jujucharms.com/charmstore/v5/~containers/"
                     "easyrsa-231/icon.svg"
                 ),
             ],
@@ -264,7 +268,7 @@ class TestStoreModels(unittest.TestCase):
             bundle.icons,
             [
                 (
-                    "https://api.jujucharms.com/v5/~containers/"
+                    "https://api.jujucharms.com/charmstore/v5/~containers/"
                     "kubernetes-master-636/icon.svg"
                 )
             ],

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -23,10 +23,7 @@ class TestStoreModels(unittest.TestCase):
 
     def test_charm(self):
         charm = models.Charm(charm_data)
-        self.assertEqual(
-            charm.archive_url,
-            "https://api.jujucharms.com/charmstore/v5/apache2-26/archive",
-        )
+        self.assertTrue(charm.archive_url.endswith("apache2-26/archive"))
         self.assertEqual(
             charm.bugs_url, "https://bugs.launchpad.net/apache2-charm"
         )
@@ -39,10 +36,7 @@ class TestStoreModels(unittest.TestCase):
         )
         self.assertEqual(charm.display_name, "apache2")
         self.assertEqual(charm.homepage, "https://launchpad.net/apache2-charm")
-        self.assertEqual(
-            charm.icon,
-            "https://api.jujucharms.com/charmstore/v5/apache2-26/icon.svg",
-        )
+        self.assertTrue(charm.icon.endswith("apache2-26/icon.svg"))
         self.assertEqual(charm.id, "cs:apache2-26")
         self.assertTrue(charm.is_charm)
         self.assertEqual(
@@ -134,19 +128,15 @@ class TestStoreModels(unittest.TestCase):
 
     def test_bundle(self):
         bundle = models.Bundle(bundle_data)
-        self.assertEqual(
-            bundle.archive_url,
-            (
-                "https://api.jujucharms.com/charmstore/v5/bundle/"
-                "canonical-kubernetes-466/archive"
-            ),
+        self.assertTrue(
+            bundle.archive_url.endswith(
+                "bundle/canonical-kubernetes-466/archive"
+            )
         )
-        self.assertEqual(
-            bundle.bundle_visualisation,
-            (
-                "https://api.jujucharms.com/charmstore/v5/bundle/"
-                "canonical-kubernetes-466/diagram.svg"
-            ),
+        self.assertTrue(
+            bundle.bundle_visualisation.endswith(
+                "bundle/canonical-kubernetes-466/diagram.svg"
+            )
         )
         self.assertEqual(
             bundle.bugs_url, "https://bugs.launchpad.net/charmed-kubernetes"
@@ -206,54 +196,39 @@ class TestStoreModels(unittest.TestCase):
 
     def test_bundle_icons(self):
         bundle = models.Bundle(bundle_data)
-        self.assertEqual(
-            bundle.icons,
-            [
-                (
-                    "https://api.jujucharms.com/charmstore/v5/~containers/"
-                    "kubernetes-master-636/icon.svg"
-                ),
-                (
-                    "https://api.jujucharms.com/charmstore/v5/~containers/"
-                    "kubernetes-worker-502/icon.svg"
-                ),
-            ],
+        self.assertTrue(
+            bundle.icons[0].endswith(
+                "~containers/kubernetes-master-636/icon.svg"
+            )
+        )
+        self.assertTrue(
+            bundle.icons[1].endswith(
+                "~containers/kubernetes-worker-502/icon.svg"
+            )
         )
 
     def test_bundle_icons_no_match(self):
         data = copy.deepcopy(bundle_data)
         data["Id"] = "cs:nothing-here-123"
         bundle = models.Bundle(data)
-        self.assertEqual(
-            bundle.icons,
-            [
-                (
-                    "https://api.jujucharms.com/charmstore/v5/"
-                    "~containers/easyrsa-231/icon.svg"
-                ),
-                (
-                    "https://api.jujucharms.com/charmstore/v5/~containers/"
-                    "etcd-411/icon.svg"
-                ),
-            ],
+        self.assertTrue(
+            bundle.icons[0].endswith("~containers/easyrsa-231/icon.svg")
+        )
+        self.assertTrue(
+            bundle.icons[1].endswith("~containers/etcd-411/icon.svg")
         )
 
     def test_bundle_icons_exact_match(self):
         data = copy.deepcopy(bundle_data)
         data["Id"] = "~containers/kubeapi-load-balancer-613"
         bundle = models.Bundle(data)
-        self.assertEqual(
-            bundle.icons,
-            [
-                (
-                    "https://api.jujucharms.com/charmstore/v5/~containers/"
-                    "kubeapi-load-balancer-613/icon.svg"
-                ),
-                (
-                    "https://api.jujucharms.com/charmstore/v5/~containers/"
-                    "easyrsa-231/icon.svg"
-                ),
-            ],
+        self.assertTrue(
+            bundle.icons[0].endswith(
+                "~containers/kubeapi-load-balancer-613/icon.svg"
+            )
+        )
+        self.assertTrue(
+            bundle.icons[1].endswith("~containers/easyrsa-231/icon.svg")
         )
 
     def test_bundle_icons_only_one(self):
@@ -264,12 +239,9 @@ class TestStoreModels(unittest.TestCase):
             }
         }
         bundle = models.Bundle(data)
-        self.assertEqual(
-            bundle.icons,
-            [
-                (
-                    "https://api.jujucharms.com/charmstore/v5/~containers/"
-                    "kubernetes-master-636/icon.svg"
-                )
-            ],
+        self.assertEqual(len(bundle.icons), 1)
+        self.assertTrue(
+            bundle.icons[0].endswith(
+                "~containers/kubernetes-master-636/icon.svg"
+            )
         )

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -9,7 +9,7 @@ from theblues.errors import EntityNotFound, ServerError
 from theblues.terms import Terms
 
 
-cs = CharmStore("https://api.jujucharms.com/v5")
+cs = CharmStore()
 terms = Terms("https://api.jujucharms.com/terms/")
 
 SEARCH_LIMIT = 400
@@ -394,7 +394,7 @@ class Bundle(Entity):
 
     def __init__(self, entity_data, include_files=False):
         super().__init__(entity_data, include_files)
-        self.bundle_visulisation = self._get_bundle_visualization()
+        self.bundle_visualisation = self._get_bundle_visualization()
         self.applications = self._parse_bundle_applications(
             self._metadata["applications"]
         )

--- a/yarn.lock
+++ b/yarn.lock
@@ -734,7 +734,6 @@
 "@canonical/global-nav@2.0.8":
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.0.8.tgz#36eafbae0be0a854e953902cd2c6152e574d5ed1"
-  integrity sha512-IM7gOBSB9QMDoo2Bp52KfmmVFzemUrPBeWKKtV0RNFod7Gn1eEZ6QOt98eiLzpPgAWomPCZdAZgV+UQekK3ffQ==
 
 "@types/estree@0.0.39":
   version "0.0.39"


### PR DESCRIPTION
## Done

- Use the default charmstore URL.
- Fix visualisation spelling.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Do a search. You should get results.
