### PR TITLE
Add service name in logs

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,5 +1,6 @@
 import flask
 import talisker.flask
+import talisker.logs
 from werkzeug.debug import DebuggedApplication
 from werkzeug.middleware.proxy_fix import ProxyFix
 
@@ -27,6 +28,7 @@ def create_app(testing=False):
 
     if not testing:
         talisker.flask.register(app)
+        talisker.logs.set_global_extra({"service": "jaas.ai"})
 
         init_extensions(app)
 


### PR DESCRIPTION
## Done

Add service name in logs to be able to play with logs

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- make sure logs end with `service=jaas.ai`
