### PR TITLE
Move Your models link

### DIFF
--- a/static/sass/custom/_header.scss
+++ b/static/sass/custom/_header.scss
@@ -6,6 +6,18 @@ $breakpoint-navigation: 980px;
   bottom: 3px;
 }
 
+.p-navigation_login {
+  order: 2;
+  margin-right: .35rem;
+}
+
+@media (min-width: $breakpoint-large) {
+  .p-navigation .p-search-box {
+    margin-right: 0;
+    max-width: 15rem;
+  }
+}
+
 @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-navigation) {
   .is-secondary-link {
     display: none !important;

--- a/templates/shared/header.html
+++ b/templates/shared/header.html
@@ -35,13 +35,15 @@
             </a>
         </li>
         <li class="p-navigation__link" role="menuitem">
-          <a class="p-link--external" href="https://discourse.jujucharms.com/">Discourse</a>
+          <a class="p-link--external" href="{{ external_urls.discourse }}">Discourse</a>
         </li>
         <li class="p-navigation__link" role="menuitem">
-          <a class="p-link--external" href="https://docs.jujucharms.com/">Docs</a>
+          <a class="p-link--external" href="{{ external_urls.docs }}">Docs</a>
         </li>
+      </ul>
+      <ul class="p-navigation__links p-navigation_login" role="menu">
         <li class="p-navigation__link" role="menuitem">
-          <a class="p-link--external" href="https://jujucharms.com/new/">Your models</a>
+          <a class="p-link--external" href="{{ external_urls.gui }}">Your models</a>
         </li>
       </ul>
     </nav>


### PR DESCRIPTION
## Done

- Move "Your models" link to after the search box.
- Resize the search box.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Resize your browser from desktop to mobile.
- The "Your models" link and search box should look good at all sizes.

## Details

- Fixes: #208.
