### PR TITLE
Add tests for fetching requires/provides

### DIFF
--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -21,6 +21,20 @@ class TestStoreModels(unittest.TestCase):
         self.assertEqual(len(results["community"]), 0)
         self.assertEqual(len(results["recommended"]), 0)
 
+    @patch("theblues.charmstore.CharmStore.fetch_interfaces")
+    def test_fetch_provides(self, mock_fetch_interfaces):
+        mock_fetch_interfaces.return_value = [None, None, search_data]
+        results = models.fetch_provides("mysql")
+        self.assertEqual(len(results["community"]), 8)
+        self.assertEqual(len(results["recommended"]), 2)
+
+    @patch("theblues.charmstore.CharmStore.fetch_interfaces")
+    def test_fetch_requires(self, mock_fetch_interfaces):
+        mock_fetch_interfaces.return_value = [None, None, search_data]
+        results = models.fetch_requires("mysql")
+        self.assertEqual(len(results["community"]), 8)
+        self.assertEqual(len(results["recommended"]), 2)
+
     def test_charm(self):
         charm = models.Charm(charm_data)
         self.assertTrue(charm.archive_url.endswith("apache2-26/archive"))

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -81,9 +81,9 @@ def get_reference(entity):
 
 def _group_status(entities):
     results = {"community": [], "recommended": []}
-    for entity in entities:
-        group = "recommended" if entity.get("promulgated") else "community"
-        results[group].append(_parse_charm_or_bundle(entity))
+    for entity in _parse_list(entities):
+        group = "recommended" if entity.promulgated else "community"
+        results[group].append(entity)
     return results
 
 


### PR DESCRIPTION
## Done

- Restore consistent list parsing (revert https://github.com/canonical-web-and-design/jaas.ai/pull/274/files).
- Add tests for fetching requires/provides.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open /search?provides=mysql
- The page should load
- Open /search?requires=mysql
- The page should load

## Details

- Fixes: #275.
