### PR TITLE
Update container image width

### DIFF
--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -216,11 +216,11 @@
       <div>
         <h2>Container management</h2>
         <p>Juju makes it easy to deploy container management solutions by provisioning, installing and configuring all the systems in the cluster.</p>
-        <p><a href="{{ url_for('jaasai.containers') }}" class="p-button--neutral">View bundles</a></p>
+        <p><a href="{{ url_for('jaasai.containers') }}">View bundles</a></p>
       </div>
     </div>
-    <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/86a111b8-CDK+bundle.svg" alt="Kubernetes promo pictogram">
+    <div class="col-7 u-hide--small u-align--right">
+      <img src="https://assets.ubuntu.com/v1/86a111b8-CDK+bundle.svg" alt="Kubernetes promo pictogram" width="330">
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Restore the container image width on the store page.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/store
- Check that the container block image looks like the one on https://github.com/canonical-web-and-design/jaas.ai/issues/283

## Details

- Fixes: #283.
