### PR TITLE
Fix clipboard icon cutting off the end of the CLI deploy command

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -341,3 +341,9 @@ h2 {
     text-decoration: none;
   }
 }
+
+// XXX Ant - 31.05.19: This can be removed when the follow issue is resolved.
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/2364
+.p-code-snippet__input {
+  padding-right: 2.5rem;
+}


### PR DESCRIPTION
## Done
Added padding to the right of the code snippet so you can see the entire value of the input when highlighting.

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/u/turku-charmers/turku-agent/3
- Highlight the content of the deploy CLI command
- Check you can see the entire command

## Details
Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/308

## Screenshots
![Screenshot_2019-05-31 Jujucharms Juju](https://user-images.githubusercontent.com/1413534/58708834-b4a97d00-83b0-11e9-8327-e5cf4ba58d4c.png)

