### PR TITLE
Fix video link spacing.

### DIFF
--- a/static/sass/custom/_homepage-hero-promo.scss
+++ b/static/sass/custom/_homepage-hero-promo.scss
@@ -44,3 +44,14 @@
     }
   }
 }
+
+.homepage-hero-card {
+  &__video-link {
+    display: inline-block;
+    margin-top: 1em;
+
+    .p-icon {
+      vertical-align: middle;
+    }
+  }
+}

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -30,14 +30,10 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-3">
                 <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}" class="p-button--positive u-no-margin--bottom">Deploy Kubernetes</a>
-              </div>
-              <div class="col-3">
-                <a href="{{ url_for('jaasai.jaas') }}#deploy-kubernetes-in-minutes">Or watch the video
+                <a href="{{ url_for('jaasai.jaas') }}#deploy-kubernetes-in-minutes" class="homepage-hero-card__video-link">Or watch the video
                   <img class="p-icon" src="https://assets.ubuntu.com/v1/0d85260e-play-icon.svg" alt="Play icon">
                 </a>
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Fix video link at different screen sizes.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Resize your screen from desktop through to mobile and watch the "Or watch the video" link (see https://github.com/canonical-web-and-design/jaas.ai/issues/292)
- The link should be spaced nicely when it wraps onto a new line.

## Details

- Fixes: #292.
