### PR TITLE
Enhance the footer with a Suru pattern

### DIFF
--- a/static/sass/custom/_patterns_icons.scss
+++ b/static/sass/custom/_patterns_icons.scss
@@ -1,0 +1,52 @@
+// XXX Ant: 26.06.2019 - Need more control over icons in the footer
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/2394
+
+@mixin jaas-p-icons {
+  .is-dark {
+    @include jaas-p-icon-facebook;
+    @include jaas-p-icon-twitter;
+    @include jaas-p-icon-youtube;
+  }
+}
+
+@mixin jaas-icon-facebook($background, $foreground) {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='40' width='40' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cdefs%3E%3Ccircle id='a' cx='20' cy='20' r='20'/%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cmask id='b' fill='%23fff'%3E%3Cuse xlink:href='%23a'/%3E%3C/mask%3E%3Cuse fill='#{vf-url-friendly-color($background)}' fill-rule='nonzero' xlink:href='%23a'/%3E%3Cpath d='M30.037 10.001c-3.92 0-6.603 2.449-6.603 6.945v3.526H19v5.255h4.434V40c1.82-.246 3.6-.728 5.3-1.438V25.727h4.423l.66-5.255h-5.084V17.47c0-1.522.48-3.085 2.55-2.563H34v-4.7c-.47-.064-2.085-.207-3.963-.207v.001z' fill='#{vf-url-friendly-color($foreground)}' fill-rule='nonzero' mask='url%28%23b%29'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+@mixin jaas-icon-twitter($background, $foreground) {
+  background-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' %3E%3Cg fill-rule='nonzero' fill='none'%3E%3Ccircle cx='20' cy='20' r='20' fill='#{vf-url-friendly-color($background)}'/%3E%3Cpath d='M16.34 30.55c8.87 0 13.72-7.35 13.72-13.72 0-.21 0-.42-.01-.62.94-.68 1.76-1.53 2.41-2.5-.86.38-1.79.64-2.77.76 1-.6 1.76-1.54 2.12-2.67-.93.55-1.96.95-3.06 1.17a4.799 4.799 0 0 0-3.52-1.52c-2.66 0-4.82 2.16-4.82 4.82 0 .38.04.75.13 1.1a13.68 13.68 0 0 1-9.94-5.04c-.41.71-.65 1.54-.65 2.42a4.8 4.8 0 0 0 2.15 4.01c-.79-.02-1.53-.24-2.18-.6v.06c0 2.34 1.66 4.28 3.87 4.73a4.807 4.807 0 0 1-2.18.08 4.815 4.815 0 0 0 4.5 3.35 9.693 9.693 0 0 1-7.14 1.99c2.11 1.38 4.65 2.18 7.37 2.18' fill='#{vf-url-friendly-color($foreground)}'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+@mixin jaas-icon-youtube($background, $foreground) {
+  background-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cdefs%3E%3Cpath id='a' d='M.009 18.367V.006h26.06v18.36z'/%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Ccircle fill='#{vf-url-friendly-color($background)}' fill-rule='nonzero' cx='20' cy='20' r='20'/%3E%3Cg transform='translate%287 11%29'%3E%3Cmask id='b' fill='%23fff'%3E%3Cuse xlink:href='%23a'/%3E%3C/mask%3E%3Cpath d='M25.524 2.868A3.275 3.275 0 0 0 23.22.548C21.187 0 13.034 0 13.034 0S4.882 0 2.85.548a3.275 3.275 0 0 0-2.305 2.32C0 4.914 0 9.183 0 9.183s0 4.27.545 6.316a3.276 3.276 0 0 0 2.305 2.32c2.032.548 10.184.548 10.184.548s8.153 0 10.185-.548a3.276 3.276 0 0 0 2.305-2.32c.545-2.047.545-6.316.545-6.316s0-4.269-.545-6.315' fill='#{vf-url-friendly-color($foreground)}' mask='url%28%23b%29'/%3E%3C/g%3E%3Cpath fill='#{vf-url-friendly-color($background)}' d='M17.368 24.06l6.814-3.876-6.814-3.877v7.753'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+@mixin jaas-p-icon-facebook {
+  .p-icon--facebook {
+    @include jaas-icon-facebook($color-x-light, $color-mid-dark);
+
+    &:hover {
+      @include jaas-icon-facebook($color-x-light, #3b5998);
+    }
+  }
+}
+
+@mixin jaas-p-icon-twitter {
+  .p-icon--twitter {
+    @include jaas-icon-twitter($color-x-light, $color-mid-dark);
+
+    &:hover {
+      @include jaas-icon-twitter($color-x-light, #1da1f2);
+    }
+  }
+}
+
+@mixin jaas-p-icon-youtube {
+  .p-icon--youtube {
+    @include jaas-icon-youtube($color-x-light, $color-mid-dark);
+
+    &:hover {
+      @include jaas-icon-youtube($color-x-light, #d9252a);
+    }
+  }
+}

--- a/static/sass/custom/_patterns_lists.scss
+++ b/static/sass/custom/_patterns_lists.scss
@@ -1,3 +1,6 @@
+// XXX Ant: 26.06.2019 - Middot is not responsive to the background colour
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/2395
+
 @mixin jaas-p-lists {
   @include jaas-p-inline-list-middot;
 }

--- a/static/sass/custom/_patterns_lists.scss
+++ b/static/sass/custom/_patterns_lists.scss
@@ -1,0 +1,20 @@
+@mixin jaas-p-lists {
+  @include jaas-p-inline-list-middot;
+}
+
+@mixin jaas-p-inline-list-middot {
+  .p-inline-list--middot {
+    @at-root .is-dark .p-inline-list__item {
+      &::after {
+        color: $color-x-light;
+        font-size: 2em;
+        right: -0.4em;
+        top: 0.3em;
+      }
+
+      &:hover::after {
+        color: $color-x-light;
+      }
+    }
+  }
+}

--- a/static/sass/custom/_patterns_lists.scss
+++ b/static/sass/custom/_patterns_lists.scss
@@ -12,7 +12,7 @@
         color: $color-x-light;
         font-size: 2em;
         right: -0.4em;
-        top: 0.3em;
+        top: 0.25em;
       }
 
       &:hover::after {

--- a/static/sass/custom/_patterns_strips.scss
+++ b/static/sass/custom/_patterns_strips.scss
@@ -4,7 +4,7 @@
   .p-strip--suru {
     @extend %vf-strip;
     background-repeat: no-repeat;
-    background-size: auto 100%, cover;
+    background-size: cover;
     overflow: hidden;
     padding-top: 8rem;
     position: relative;

--- a/static/sass/custom/_patterns_strips.scss
+++ b/static/sass/custom/_patterns_strips.scss
@@ -1,0 +1,51 @@
+@mixin jaas-p-strips {
+  $suru-accent: #3fc8f2;
+
+  .p-strip--suru {
+    @extend %vf-strip;
+    background-repeat: no-repeat;
+    background-size: auto 100%, cover;
+    overflow: hidden;
+    padding-top: 8rem;
+    position: relative;
+
+    &::before {
+      background: linear-gradient(
+        to bottom right,
+        rgba(255, 255, 255, 1) 0%,
+        rgba(255, 255, 255, 1) 49%,
+        rgba(255, 255, 255, 0) 50%,
+        rgba(255, 255, 255, 0) 100%
+      );
+      content: '';
+      display: block;
+      height: 4rem;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: 100%;
+      z-index: 2;
+    }
+
+    &::after {
+      background: $suru-accent;
+      content: '';
+      display: block;
+      height: 100px;
+      position: absolute;
+      right: -100px;
+      top: -50px;
+      transform: rotate(15deg);
+      width: 300px;
+      z-index: 1;
+    }
+
+    &.is-light {
+      color: $color-x-dark;
+    }
+
+    &.is-dark {
+      color: $color-x-light;
+    }
+  }
+}

--- a/static/sass/custom/_patterns_strips.scss
+++ b/static/sass/custom/_patterns_strips.scss
@@ -34,9 +34,9 @@
       height: 100px;
       position: absolute;
       right: -100px;
-      top: -50px;
+      top: -70px;
       transform: rotate(15deg);
-      width: 300px;
+      width: 500px;
       z-index: 1;
     }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -42,6 +42,12 @@ $mid-grey: $color-mid-light;
 @import 'custom/modal';
 @import 'custom/header';
 @import 'custom/series_tags';
+@import 'custom/patterns_strips';
+@import 'custom/patterns_lists';
+@import 'custom/patterns_icons';
+@include jaas-p-strips;
+@include jaas-p-lists;
+@include jaas-p-icons;
 
 // github component homepage
 .github-actions {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -353,3 +353,7 @@ h2 {
 .p-code-snippet__input {
   padding-right: 2.5rem;
 }
+
+.u-no-max-width {
+  max-width: none !important;
+}

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -75,7 +75,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
 </script>
 
-<footer class="p-strip--suru is-dark" style="background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(-266deg, #044f66, #022935)">
+<footer class="p-strip--suru is-dark" style="background-size: auto 100%, cover; background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(-266deg, #044f66, #022935)">
   <div class="row">
     <div class="col-8">
         <p>&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.</p>

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -78,7 +78,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <footer class="p-strip--suru is-dark" style="background-size: auto 100%, cover; background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(266deg, #044f66, #022935)">
   <div class="row">
     <div class="col-8">
-        <p>&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.</p>
+        <p class="u-no-max-width">&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
         <ul class="p-inline-list--middot">
           <li class="p-inline-list__item">
             <a class="p-link--inverted p-link--external" href="https://www.ubuntu.com/legal">Legal Information</a>

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -75,7 +75,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
 </script>
 
-<footer class="p-strip--suru is-dark" style="background-size: auto 100%, cover; background-image: url('https://assets.ubuntu.com/v1/ed8f5612-jaas-suru-background.svg'), linear-gradient(266deg, #044f66, #022935)">
+<footer class="p-strip--suru is-dark" style="background-size: auto 100%, cover; background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(266deg, #044f66, #022935)">
   <div class="row">
     <div class="col-8">
         <p>&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.</p>

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -75,31 +75,31 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
 </script>
 
-<footer class="p-footer">
+<footer class="p-strip--suru is-dark" style="background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(-266deg, #044f66, #022935)">
   <div class="row">
     <div class="col-8">
-        <div>&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</div>
-        <ul class="p-footer__links">
-          <li class="p-footer__item">
-            <a class="p-footer__link p-link--external" href="https://www.ubuntu.com/legal">Legal Information</a>
+        <p>&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.</p>
+        <ul class="p-inline-list--middot">
+          <li class="p-inline-list__item">
+            <a class="p-link--inverted p-link--external" href="https://www.ubuntu.com/legal">Legal Information</a>
           </li>
-          <li class="p-footer__item">
-            <a class="p-footer__link" href="{{ external_urls.issues }}">Report a bug on this site</a>
+          <li class="p-inline-list__item">
+            <a class="p-link--inverted" href="{{ external_urls.issues }}">Report a bug on this site</a>
           </li>
         </ul>
-        <nav class="p-footer__nav">
-          <ul class="p-footer__links">
-            <li class="p-footer__item">
-              <a class="p-footer__link" href="{{ external_urls.docs }}getting-started">Docs</a>
+        <nav>
+          <ul class="p-inline-list--middot">
+            <li class="p-inline-list__item">
+              <a class="p-link--inverted" href="{{ external_urls.docs }}getting-started">Docs</a>
             </li>
-            <li class="p-footer__item">
-              <a class="p-footer__link" href="{{ url_for('jaasai.community') }}">Community</a>
+            <li class="p-inline-list__item">
+              <a class="p-link--inverted" href="{{ url_for('jaasai.community') }}">Community</a>
             </li>
-            <li class="p-footer__item">
-              <a class="p-footer__link p-link--external" href="{{ external_urls.blog }}">Blog</a>
+            <li class="p-inline-list__item">
+              <a class="p-link--inverted p-link--external" href="{{ external_urls.blog }}">Blog</a>
             </li>
-            <li class="p-footer__item">
-              <a class="p-footer__link p-link--external" href="{{ external_urls.docs }}en/reference-install">Install Juju</a>
+            <li class="p-inline-list__item">
+              <a class="p-link--inverted p-link--external" href="{{ external_urls.docs }}en/reference-install">Install Juju</a>
             </li>
           </ul>
           <span class="u-off-screen">
@@ -107,8 +107,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </span>
       </nav>
     </div>
-    <div class="col-4">
-      <ul class="p-inline-list u-no-margin--top">
+    <div class="col-4 u-align--right">
+      <ul class="p-inline-list">
         <li class="p-inline-list__item">
             <a href="http://www.facebook.com/ubuntucloud" class="p-icon--facebook"></a>
         </li>

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -75,7 +75,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
 </script>
 
-<footer class="p-strip--suru is-dark" style="background-size: auto 100%, cover; background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(-266deg, #044f66, #022935)">
+<footer class="p-strip--suru is-dark" style="background-size: auto 100%, cover; background-image: url('https://assets.ubuntu.com/v1/ed8f5612-jaas-suru-background.svg'), linear-gradient(266deg, #044f66, #022935)">
   <div class="row">
     <div class="col-8">
         <p>&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.</p>


### PR DESCRIPTION
## Done
Added a new suru strip pattern and applied it to the footer of the site. Inverted a number of patterns namely the middot list and social icons.

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Scroll to the footer and check it matches [the design](https://app.zeplin.io/project/5cf8ca699ee7bf1df9082012/screen/5cfe111fdd0ff045f08a2da8)
- Check small screens works ok
- _The background pattern does not match the design as the asset is not easy to embed. I have used one from a takeover for now_ 

## Details
Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/322

## Screenshots
Desktop:
![Screenshot_2019-06-26 Jujucharms Juju(2)](https://user-images.githubusercontent.com/1413534/60179018-964e6a00-9814-11e9-823f-542ecf27cd6c.png)

Small screen:
![Screenshot_2019-06-26 Jujucharms Juju(3)](https://user-images.githubusercontent.com/1413534/60179024-9c444b00-9814-11e9-9382-25ca005a7a37.png)

