### PR TITLE
Add the is-slanted state to the strips pattern

### DIFF
--- a/static/sass/custom/_patterns_strips.scss
+++ b/static/sass/custom/_patterns_strips.scss
@@ -89,7 +89,7 @@
 @mixin jaas-p-strip-slanted {
   [class*='p-strip'].is-slanted {
     overflow: hidden;
-    padding-top: 8rem;
+    padding-bottom: 8rem;
     position: relative;
 
     &::before {

--- a/static/sass/custom/_patterns_strips.scss
+++ b/static/sass/custom/_patterns_strips.scss
@@ -24,7 +24,7 @@
     }
 
     &::after {
-      background: $color-suru-accent;
+      background: $suru-accent;
       content: '';
       display: block;
       height: 100px;

--- a/static/sass/custom/_patterns_strips.scss
+++ b/static/sass/custom/_patterns_strips.scss
@@ -1,5 +1,10 @@
 @mixin jaas-p-strips {
-  $color-suru-accent: #3fc8f2;
+  @include jaas-p-strip-suru;
+  @include jaas-p-strip-slanted;
+}
+
+@mixin jaas-p-strip-suru {
+  $suru-accent: #3fc8f2;
 
   %jaas-strip-suru {
     @extend %vf-strip;
@@ -77,6 +82,32 @@
     &::after {
       bottom: -70px;
       left: -100px;
+    }
+  }
+}
+
+@mixin jaas-p-strip-slanted {
+  [class*='p-strip'].is-slanted {
+    overflow: hidden;
+    padding-top: 8rem;
+    position: relative;
+
+    &::before {
+      background: linear-gradient(
+        to top left,
+        rgba(255, 255, 255, 1) 0%,
+        rgba(255, 255, 255, 1) 49%,
+        rgba(255, 255, 255, 0) 50%,
+        rgba(255, 255, 255, 0) 100%
+      );
+      content: '';
+      display: block;
+      height: 4rem;
+      left: 0;
+      position: absolute;
+      bottom: 0;
+      width: 100%;
+      z-index: 2;
     }
   }
 }

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -75,7 +75,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
 </script>
 
-<footer class="p-strip--suru--top is-dark" style="background-size: auto 100%, cover; background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(266deg, #044f66, #022935)">
+<footer class="p-strip--suru-top is-dark" style="background-size: auto 100%, cover; background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(266deg, #044f66, #022935)">
   <div class="row">
     <div class="col-8">
         <p class="u-no-max-width">&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -42,7 +42,7 @@
     </div>
   </div>
 
-  <div class="p-strip is-bordered homepage-hero-promos u-no-margin--top">
+  <div class="p-strip--light is-slanted homepage-hero-promos u-no-margin--top">
     <div class="row">
       <div class="u-equal-height">
         <div class="col-4 has-strap">


### PR DESCRIPTION
## Done
Added `is-slanted` as a state class to strips.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Go to the homepage and check the section strip "Juju expert partners" is slanted at the bottom

## Details
Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/324

## Screenshots
![Screenshot_2019-06-27 Jujucharms Juju(1)](https://user-images.githubusercontent.com/1413534/60275429-d8011280-98f1-11e9-8788-adffda8c5a67.png)

