### PR TITLE
Add dynamic year variable to footer

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -78,7 +78,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <footer class="p-strip--suru-top has-accent is-dark" style="background-size: auto 100%, cover; background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(266deg, #044f66, #022935)">
   <div class="row">
     <div class="col-8">
-        <p class="u-no-max-width">&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+        <p class="u-no-max-width">&copy; {{ current_year }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
         <ul class="p-inline-list--middot">
           <li class="p-inline-list__item">
             <a class="p-link--inverted p-link--external" href="https://www.ubuntu.com/legal">Legal Information</a>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,4 +1,5 @@
 import flask
+import datetime
 
 from canonicalwebteam.flask_base.app import FlaskBase
 from webapp.external_urls import external_urls
@@ -36,6 +37,10 @@ def create_app(testing=False):
             "external_urls": external_urls,
             "static_url": static_url,
         }
+
+    @app.context_processor
+    def inject_today_date():
+        return {"current_year": datetime.date.today().year}
 
     app.jinja_env.add_extension("jinja2.ext.do")
 


### PR DESCRIPTION
## Done

Add dynamic year variable to footer

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- View footer and verify year on copyright notice is '2019'

## Details

Fixes #349

