### PR TITLE
Fix spacing on /experts strap

### DIFF
--- a/templates/jaasai/experts/spicule.html
+++ b/templates/jaasai/experts/spicule.html
@@ -127,7 +127,7 @@
       </h4>
     </div>
     <div class="col-4">
-      <span class="expert__strap">Become a Partner</span>
+      <p class="expert__strap">Become a Partner</p>
       <div class="expert__actions">
         <a
           href="mailto:juju-experts@canonical.com"

--- a/templates/jaasai/experts/tengu.html
+++ b/templates/jaasai/experts/tengu.html
@@ -118,7 +118,7 @@
       </h4>
     </div>
     <div class="col-4">
-      <span class="expert__strap">Become a Partner</span>
+      <p class="expert__strap">Become a Partner</p>
       <div class="expert__actions">
         <a
           href="mailto:juju-experts@canonical.com"


### PR DESCRIPTION
## Done

Fix spacing on /experts strap

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/experts/spicule & http://0.0.0.0:8029/experts/tengu
- check spacing on 'Join us' CTA button

## Details

Fixes #347