### PR TITLE
Fix broken link on /how-it-works

### DIFF
--- a/templates/jaasai/how-it-works.html
+++ b/templates/jaasai/how-it-works.html
@@ -184,7 +184,7 @@
           how to upgrade it.
         </p>
         <p>
-          <a class="external external-alt" href="{{ external_urls.docs }}charms">
+          <a href="{{ external_urls.docs }}applications-and-charms">
             Learn more about charms&nbsp;&rsaquo;
           </a>
         </p>


### PR DESCRIPTION
## Done

Fix broken link on /how-it-works, removed redundant classes

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/how-it-works
- Scroll to ' Learn more about charms ›'
- Check link works

## Details

Fixes #360
