### PR TITLE
Fix rendering of charms without readmes

### DIFF
--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -184,9 +184,13 @@ class Entity:
         self.readme = None
         if include_files:
             self.files = self._get_entity_files(self._meta.get("manifest"))
-            self.readme = self._render_markdown(
-                cs.entity_readme_content(self.id)
-            )
+            try:
+                self.readme = self._render_markdown(
+                    cs.entity_readme_content(self.id)
+                )
+            except Exception:
+                # Leave the readme unparsed.
+                pass
         self.archive_url = cs.archive_url(self._ref)
         self.bugs_url = bugs_url
         self.card_id = self._ref.path()

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -185,6 +185,8 @@ class Entity:
         if include_files:
             self.files = self._get_entity_files(self._meta.get("manifest"))
             try:
+                # If the readme is not available for the charm we pass
+                # unparsed.
                 self.readme = self._render_markdown(
                     cs.entity_readme_content(self.id)
                 )


### PR DESCRIPTION
## Done
Added a catch for missing readme and pass parsed is not available.

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check out the problem charm: http://0.0.0.0:8029/u/canonical-bootstack/thruk-master/6
- Check a charm with a readme: http://0.0.0.0:8029/mysql

## Details
Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/367
