### PR TITLE
Disable add-to-canvas button on kubernetes charms.

### DIFF
--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -41,8 +41,8 @@
               {{ supported_release }}
             </span>
           {% endfor %}
-        {% endif %}
       </div>
+      {% endif %}
     </div>
     <div class="col-4">
       <div class="p-code-snippet">
@@ -51,10 +51,16 @@
         <button class="p-code-snippet__action">Copy to clipboard</button>
       </div>
       <p>
-        <a href="{{ external_urls.gui }}?deploy-target={{ context.entity.id }}"
-          class="p-button--positive row" rel="nofollow">
-          Add to new model
-        </a>
+        {% if "kubernetes" in context.entity.series %}
+          <a class="p-button--neutral row is-disabled" aria-disabled="true">
+            Use the Juju CLI to deploy
+          </a>
+        {% else %}
+          <a href="{{ external_urls.gui }}?deploy-target={{ context.entity.id }}"
+            class="p-button--positive row" rel="nofollow">
+            Add to new model
+          </a>
+        {% endif %}
       </p>
     </div>
   </header>

--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -50,18 +50,19 @@
           readonly="readonly">
         <button class="p-code-snippet__action">Copy to clipboard</button>
       </div>
-      <p>
         {% if "kubernetes" in context.entity.series %}
-          <a class="p-button--neutral row is-disabled" aria-disabled="true">
-            Use the Juju CLI to deploy
-          </a>
+          <div class="p-notification--information">
+            <p class="p-notification__response">
+              Deploy this charm on Kubernetes with the CLI. Find out how by reading the
+              <a href="https://docs.jujucharms.com/k8s-cloud">Discourse discussion</a>.
+            </p>
+          </div>
         {% else %}
           <a href="{{ external_urls.gui }}?deploy-target={{ context.entity.id }}"
             class="p-button--positive row" rel="nofollow">
             Add to new model
           </a>
         {% endif %}
-      </p>
     </div>
   </header>
 </div>

--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -45,24 +45,23 @@
       {% endif %}
     </div>
     <div class="col-4">
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input deploy-command__field" value="juju deploy {{ context.entity.id }}"
-          readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
+      <div class="p-code-copyable">
+        <input class="p-code-copyable__input" value="juju deploy {{ context.entity.id }}" readonly="readonly">
+        <button class="p-code-copyable__action">Copy to clipboard</button>
       </div>
-        {% if "kubernetes" in context.entity.series %}
-          <div class="p-notification--information">
-            <p class="p-notification__response">
-              Deploy this charm on Kubernetes with the CLI. Find out how by reading the
-              <a href="https://docs.jujucharms.com/k8s-cloud">Discourse discussion</a>.
-            </p>
-          </div>
-        {% else %}
-          <a href="{{ external_urls.gui }}?deploy-target={{ context.entity.id }}"
-            class="p-button--positive row" rel="nofollow">
-            Add to new model
-          </a>
-        {% endif %}
+      {% if "kubernetes" in context.entity.series %}
+        <div class="p-notification--information">
+          <p class="p-notification__response">
+            Deploy this charm on Kubernetes with the CLI. Find out how by reading the
+            <a class="p-link--external" href="https://docs.jujucharms.com/k8s-cloud">Discourse discussion</a>.
+          </p>
+        </div>
+      {% else %}
+        <a href="{{ external_urls.gui }}?deploy-target={{ context.entity.id }}"
+          class="p-button--positive" rel="nofollow" style="width:100%">
+          Add to new model
+        </a>
+      {% endif %}
     </div>
   </header>
 </div>


### PR DESCRIPTION
## Done

Disable add-to-canvas button on kubernetes charms.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/u/containers/coredns/0 and the button should not take you to the GUI.
- Open a charm and a bundle that are not kubernetes and their 'add-to-canvas' buttons should take you to the GUI.

## Details

Fixes #333 

## Screenshots

![Screen Shot 2019-07-23 at 12 07 11 PM](https://user-images.githubusercontent.com/532033/61736025-6bd3cc00-ad42-11e9-87b6-7b5fa2e12ffb.png)

