### PR TITLE
Fix Charmstore timeouts

### DIFF
--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -23,20 +23,6 @@
             </span>
           </li>
         {% endif %}
-        {% if context.entity.latest_revision and context.entity.revision_number != context.entity.latest_revision %}
-          <li class="p-inline-list__item">
-            <span class="entity__latest-version">
-              <a href="/{{ context.entity.latest_revision['url'] }}" onclick="dataLayer.push({
-                    'event' : 'GAEvent',
-                    'eventCategory' : 'Entity Details Link',
-                    'eventAction' : 'Goto latest version',
-                    'eventLabel' : 'Latest version (#ID)',
-                    'eventValue' : '{{ context.entity.latest_revision['full_id'] }}'
-                  });"><strong>Latest version</strong> (#{{ context.entity.latest_revision.id }})
-              </a>
-            </span>
-          </li>
-        {% endif %}
         {% if context.entity.channels %}
           <li class="p-inline-list__item">
             <span class="entity__channel">

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -54,14 +54,6 @@ class TestStoreModels(unittest.TestCase):
         self.assertEqual(charm.id, "cs:apache2-26")
         self.assertTrue(charm.is_charm)
         self.assertEqual(
-            charm.latest_revision,
-            {
-                "full_id": "cs:precise/apache2-27",
-                "id": 27,
-                "url": "apache2/precise/27",
-            },
-        )
-        self.assertEqual(
             charm.options.get("apt-key-id"),
             {
                 "Type": "string",
@@ -177,14 +169,6 @@ class TestStoreModels(unittest.TestCase):
         )
         self.assertEqual(bundle.id, "cs:bundle/canonical-kubernetes-466")
         self.assertFalse(bundle.is_charm)
-        self.assertEqual(
-            bundle.latest_revision,
-            {
-                "id": 530,
-                "full_id": "cs:bundle/canonical-kubernetes-530",
-                "url": "canonical-kubernetes/bundle/530",
-            },
-        )
         self.assertEqual(bundle.owner, "containers")
         self.assertIsNone(bundle.promulgated)
         self.assertEqual(bundle.revision_number, 466)

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -4,7 +4,7 @@ import os
 import re
 
 from jujubundlelib import references
-from theblues.charmstore import CharmStore, DEFAULT_INCLUDES
+from theblues.charmstore import CharmStore
 from theblues.errors import EntityNotFound, ServerError
 from theblues.terms import Terms
 
@@ -117,10 +117,8 @@ def get_user_entities(username):
 
 
 def get_charm_or_bundle(reference):
-    includes = DEFAULT_INCLUDES[:]
-    includes.append("revision-info")
     try:
-        entity_data = cs.entity(reference, True, includes=includes)
+        entity_data = cs.entity(reference, True, include_stats=False)
         return _parse_charm_or_bundle(entity_data, include_files=True)
     except EntityNotFound:
         return None
@@ -204,7 +202,6 @@ class Entity:
         )
         self.display_name = self._get_display_name()
         self.homepage = homepage
-        self.latest_revision = self._get_latest_revision()
         self.owner = self._meta.get("owner", {}).get("User")
         self.promulgated = self._meta.get("promulgated", {}).get("Promulgated")
         self.revision_number = self._ref.revision
@@ -253,21 +250,6 @@ class Entity:
         except EntityNotFound:
             files = {}
         return files
-
-    def _get_latest_revision(self):
-        """Get the latest revision for an entity.
-            :returns: The latest revision details.
-        """
-        revision_list = self._meta.get("revision-info", {}).get("Revisions")
-        latest_revision = None
-        if revision_list:
-            ref = references.Reference.from_string(revision_list[0])
-            latest_revision = {
-                "id": ref.revision,
-                "full_id": revision_list[0],
-                "url": ref.jujucharms_id(),
-            }
-        return latest_revision
 
     def _extract_from_extrainfo(self):
         """Get data from extrainfo.


### PR DESCRIPTION
## Done

Fix Charmstore timeouts.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- `Latest revision` element should be gone but other than that, charm and bundle pages should remain functional.
- Timeouts are intermittent so we'll only see if this works once released and the logs show fewer timeouts.

## Details

Fixes #381 

