### PR TITLE
Add search module for documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: sleep 5
       - run:
           name: Run Linkchecker
-          command: linkchecker --threads 2 -r 2 --verbose --ignore-url /search/* --ignore-url /store/* --no-warnings http://0.0.0.0:8029
+          command: linkchecker --threads 2 -r 2 --verbose --ignore-url /docs/* --ignore-url /search/* --ignore-url /store/* --no-warnings http://0.0.0.0:8029
   check-build:
     <<: *defaults
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ gfm==0.0.3
 jujubundlelib==0.5.6
 theblues==0.5.1
 canonicalwebteam.discourse-docs==0.6.0
+canonicalwebteam.search==0.1.0

--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -1,0 +1,5 @@
+{% extends "docs/base.html" %}
+
+{% block content_docs %}
+  {{ results }}
+{% endblock %}

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -6,6 +6,8 @@ from canonicalwebteam.discourse_docs import (
     DocParser,
 )
 
+from canonicalwebteam.search import build_search_view
+
 
 def init_docs(app, url_prefix):
     discourse_index_id = 1868
@@ -48,3 +50,11 @@ def init_docs(app, url_prefix):
         return flask.render_template(
             "docs/commands.html", navigation=discourse_parser.navigation
         )
+
+    app.add_url_rule(
+        "/docs/search",
+        "docs-search",
+        build_search_view(
+            site="docs.jujucharms.com", template_path="docs/search.html"
+        ),
+    )


### PR DESCRIPTION
## Done

- Add search module to jaas.ai
- add basic template

## QA

Get hold of the "Custom Search API key" from the Google cloud API credentials page - if you don't have access to that page, ask @nottrobin/@tbille or someone for access.

Then, run the site with:

- `./run --env SEARCH_API_KEY={the-api-key}`
- http://0.0.0.0:8029/docs/search?q=test
- Should have a dictionnary full of results. Just needs templating now!
