### PR TITLE
Fix broken docs homepage links

### DIFF
--- a/templates/docs/homepage.html
+++ b/templates/docs/homepage.html
@@ -15,7 +15,7 @@
       <div class="u-equal-height">
         <div class="col-6">
           <h2>Getting started</h2>
-          <p><a href="/getting-started-with-juju/1134">Getting started with Juju&nbsp;&rsaquo;</a></p>
+          <p><a href="/docs/getting-started-with-juju/1134">Getting started with Juju&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-6 u-align--right">
           <img style="border: 0" src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg">
@@ -27,20 +27,20 @@
       <div class="u-equal-height">
         <div class="col-6">
           <ul class="p-list">
-            <li class="p-list__item"><a href="/whats-new-in-2-6/1202">New features in 2.6&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/clouds/1100">Clouds&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/using-vmware-vsphere-with-juju/1099">Using VMware vSphere with Juju&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/using-kubernetes-with-juju/1090">Using Kubernetes with Juju&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/understanding-kubernetes-charms-tutorial/1263">Understanding Kubernetes charms&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/docs/whats-new-in-2-6/1202">New features in 2.6&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/docs/clouds/1100">Clouds&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/docs/using-vmware-vsphere-with-juju/1099">Using VMware vSphere with Juju&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/docs/using-kubernetes-with-juju/1090">Using Kubernetes with Juju&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/docs/understanding-kubernetes-charms-tutorial/1263">Understanding Kubernetes charms&nbsp;&rsaquo;</a></li>
           </ul>
         </div>
         <div class="col-6">
           <ul class="p-list">
-            <li class="p-list__item"><a href="/migrating-models/1152">Migrating models&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/bundle-reference/1158">Bundle reference&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/using-juju-with-microk8s-tutorial/1194">Using Juju with MicroK8s&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/removing-things/1063">Removing things&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/controller-logins/1389">Controller logins&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/docs/migrating-models/1152">Migrating models&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/docs/bundle-reference/1158">Bundle reference&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/docs/using-juju-with-microk8s-tutorial/1194">Using Juju with MicroK8s&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/docs/removing-things/1063">Removing things&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/docs/controller-logins/1389">Controller logins&nbsp;&rsaquo;</a></li>
           </ul>
         </div>
       </div>
@@ -52,24 +52,24 @@
             <li class="p-list__item">
               <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/039628d5-picto-community-orange.svg');
               height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
-              <a class="p-link--external" href="https://jujucharms.com/community">Community</a>
+              <a class="p-link--external" href="/community">Community</a>
             </li>
             <li class="p-list__item">
               <i class="p-icon"
                   style="background-image:url('https://assets.ubuntu.com/v1/fa38eb81-picto-business-midaubergine.svg');
                         height:1.5rem;width: 1.5rem;top:
                         2px;margin-right:.5rem;"></i>
-              <a href="/managed-solutions/1132">Managed solutions</a>
+              <a href="/docs/managed-solutions/1132">Managed solutions</a>
             </li>
             <li class="p-list__item">
               <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/4ef84d88-picto-quote-warmgrey.svg');
               height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
-              <a class="p-link--external" href="https://blog.ubuntu.com/tag/juju">Blog</a>
+              <a class="p-link--external" href="https://ubuntu.com/blog/tag/juju">Blog</a>
             </li>
             <li class="p-list__item">
               <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg');
               height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
-              <a class="p-link--external" href="http://askubuntu.com/questions/tagged/juju">Ask a question</a>
+              <a class="p-link--external" href="https://discourse.jujucharms.com/">Ask a question</a>
             </li>
             <li class="p-list__item">
               <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/422b612c-picto-forum-warmgrey.svg');


### PR DESCRIPTION
## Done

Fix broken docs homepage links

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/docs
- Verify all the links in main content area no longer 404

Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/389
