### PR TITLE
Switch out 'Ask Ubuntu' links for Discourse links

### DIFF
--- a/templates/jaasai/community.html
+++ b/templates/jaasai/community.html
@@ -130,8 +130,8 @@
       <p>Join the Juju community on our <a href="{{ external_urls.discourse }}">Discourse forum</a>.</p>
     </div>
     <div class="col-4">
-      <h5>Ask Ubuntu</h5>
-      <p>Find out more, get help or ask any question at <a class="p-link--external" href="{{ external_urls.askubuntu }}">Ask Ubuntu</a>.</p>
+      <h5>Discourse</h5>
+      <p>Find out more, get help or ask any question on our <a class="p-link--external" href="{{ external_urls.discourse }}">Discourse</a>.</p>
     </div>
     <div class="col-4">
       <h5>Social</h5>

--- a/templates/jaasai/community.html
+++ b/templates/jaasai/community.html
@@ -130,8 +130,8 @@
       <p>Join the Juju community on our <a href="{{ external_urls.discourse }}">Discourse forum</a>.</p>
     </div>
     <div class="col-4">
-      <h5>Discourse</h5>
-      <p>Find out more, get help or ask any question on our <a class="p-link--external" href="{{ external_urls.discourse }}">Discourse</a>.</p>
+      <h5>Freenode</h5>
+      <p>Find out more, get help or ask any question on our <a class="p-link--external" href="{{ external_urls.freenode }}">Freenode IRC channel</a>.</p>
     </div>
     <div class="col-4">
       <h5>Social</h5>

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -276,13 +276,13 @@
   </div>
 </div>
 
-  <div class="p-strip u-no-padding--bottom">
-    <div class="row">
-      <div class="col-12">
-        <h2>What people are saying about Juju</h2>
-      </div>
+<div class="p-strip u-no-padding--bottom">
+  <div class="row">
+    <div class="col-12">
+      <h2>What people are saying about Juju</h2>
     </div>
   </div>
+</div>
 
 <div class="p-strip is-shallow">
   <div class="row">

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -271,7 +271,7 @@
     </div>
     <div class="col-4 p-divider__block">
       <h4>Ask the community</h4>
-      <p>Find out more, get help or ask any question at <a class="p-link--external" href="{{ external_urls.askubuntu }}">Ask Ubuntu</a></p>
+      <p>Find out more, get help or ask any question on our <a class="p-link--external" href="{{ external_urls.discourse }}">Discourse</a></p>
     </div>
   </div>
 </div>

--- a/webapp/external_urls.py
+++ b/webapp/external_urls.py
@@ -6,4 +6,5 @@ external_urls = {
     "docs": "https://docs.jujucharms.com/",
     "gui": "https://jujucharms.com/new/",
     "issues": "https://github.com/canonical-web-and-design/jaas.ai/issues",
+    "freenode": "http://webchat.freenode.net/?channels=%23juju",
 }

--- a/webapp/external_urls.py
+++ b/webapp/external_urls.py
@@ -1,5 +1,5 @@
 external_urls = {
-    "askubuntu": "https://askubuntu.com/questions/tagged/juju",
+    "discourse": "https://discourse.jujucharms.com/",
     "blog": "https://blog.ubuntu.com/topics/juju",
     "charmstore": "https://api.jujucharms.com/charmstore/v5/",
     "discourse": "https://discourse.jujucharms.com/",


### PR DESCRIPTION
## Done

Switch out 'Ask Ubuntu' links for Discourse links

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check links to Discourse load as expected

## Details

Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/387
