### PR TITLE
Sitemap and change search to jaas.ai/docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 canonicalwebteam.http==1.0.1
 canonicalwebteam.flask_base==0.3.1
 canonicalwebteam.yaml-responses==1.1.1
+canonicalwebteam.discourse-docs==0.6.4
+canonicalwebteam.search==0.1.0
 feedparser==5.2.1
 Flask-Testing==0.7.1
 Flask==1.1.1
 gfm==0.0.3
 jujubundlelib==0.5.6
 theblues==0.5.1
-canonicalwebteam.discourse-docs==0.6.0
-canonicalwebteam.search==0.1.0

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -55,6 +55,6 @@ def init_docs(app, url_prefix):
         "/docs/search",
         "docs-search",
         build_search_view(
-            site="docs.jujucharms.com", template_path="docs/search.html"
+            site="jaas.ai/docs", template_path="docs/search.html"
         ),
     )


### PR DESCRIPTION
Upgrade to canonicalwebteam.discourse-docs v0.6.2 so we get a
/docs/sitemap.txt endpoint.

Change search to return results from jaas.ai/docs rather than
docs.jaas.ai.

QA
--

`./run --env SEARCH_API_KEY={thekey}`, go to `/docs/sitemap.txt` and see it in all its glory.

Go to `/docs/search`, search for things, see the results returned are at `jaas.ai/docs`.