### PR TITLE
Fix “Copy to clipboard” function in entity header

### DIFF
--- a/static/js/src/modules/copy-snippet.js
+++ b/static/js/src/modules/copy-snippet.js
@@ -8,11 +8,11 @@ const copySnippet = () => {
     @static
   **/
   const instantiateCopyButtons = () => {
-    var codeSnippetActions = document.querySelectorAll('.p-code-snippet__action');
+    var codeSnippetActions = document.querySelectorAll('.p-code-copyable__action');
     for (var codeSnippetAction of codeSnippetActions) {
       codeSnippetAction.addEventListener(
         'click',
-        function(e) {
+        function() {
           const clipboardValue = this.previousSibling.previousSibling.value;
           copyToClipboard(clipboardValue);
         },


### PR DESCRIPTION
## Done

Fix “Copy to clipboard” function in entity header

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/u/containers/coredns/0
- Click "Copy to clipboard" button
- Verify text is on clipboard

Fixes #400
