### PR TITLE
increase charmstore timeout

### DIFF
--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -9,7 +9,7 @@ from theblues.errors import EntityNotFound, ServerError
 from theblues.terms import Terms
 
 
-cs = CharmStore()
+cs = CharmStore(timeout=5)
 terms = Terms("https://api.jujucharms.com/terms/")
 
 SEARCH_LIMIT = 400


### PR DESCRIPTION
## Done
Increased charmstore request timeout from the default 3.05s to 5s.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Use the site as normal - nothing should be broken by this change
- Deploy to staging and do the same
- Deploy to production and see the amount of noise on sentry decrease

## Details

At low usage times (UK AM) some pages (/u/openstack-charmers-next for example) take 2-3s to load the initial document, close to the 3.05s timeout threshold (obviously some of the time is taken up by other things), at peak usage times this will be worse.

I think it's better to take some time to show a user what they've asked for rather than show them nothing.

This is a short term solution to something more robust (https://github.com/canonical-web-and-design/jaas.ai/issues/7)
