### PR TITLE
Swap out gfm for py-gfm to support backticks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ canonicalwebteam.search==0.1.0
 feedparser==5.2.1
 Flask-Testing==0.7.1
 Flask==1.1.1
-gfm==0.0.3
+py-gfm==0.1.4
 jujubundlelib==0.5.6
 theblues==0.5.1
+Markdown==2.6.11

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -1,8 +1,9 @@
 import collections
-import gfm
 import os
 import re
+import markdown
 
+from mdx_gfm import GithubFlavoredMarkdownExtension
 from jujubundlelib import references
 from theblues.charmstore import CharmStore
 from theblues.errors import EntityNotFound, ServerError
@@ -220,7 +221,9 @@ class Entity:
             :content string: Some markdown.
             :returns: HTML as a string.
         """
-        html = gfm.markdown(content)
+        html = markdown.markdown(
+            content, extensions=[GithubFlavoredMarkdownExtension()]
+        )
         try:
             html = self._convert_http_to_https(html)
         except Exception:


### PR DESCRIPTION
## Done

Swap out `gfm` for `py-gfm` to support backticks to represent code

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/u/openstack-charmers-next/nova-cloud-controller#configuration
- Scroll above the section linked above and verify that the large code black in the screenshot below is parsed as indented code.

## Details

Fixes #410

## Screenshots

<img width="968" alt="Screenshot 2019-08-13 at 12 26 18" src="https://user-images.githubusercontent.com/505570/62937814-948d3580-bdc5-11e9-97f0-ffea60a4f114.png">

