### PR TITLE
Add Omnivector & Tengu contact forms

### DIFF
--- a/templates/jaasai/experts/omnivector.html
+++ b/templates/jaasai/experts/omnivector.html
@@ -145,27 +145,6 @@
   </div>
 </div>
 
-<div class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      <span class="expert__strap">Juju Expert Partners</span>
-      <h4>
-        Managed solutions partner network. If you are building your own
-        solutions we would love to have you join us as a partner. We can’t wait
-        to talk.
-      </h4>
-    </div>
-    <div class="col-4">
-      <p class="expert__strap">Become a Partner</p>
-      <div class="expert__actions">
-        <a
-          href="mailto:juju-experts@canonical.com"
-          class="p-button--positive">
-          Join us&hellip;
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
+{% include "shared/_expert_partner_cta_strip.html" %}
 
 {% endblock content %}

--- a/templates/jaasai/experts/spicule.html
+++ b/templates/jaasai/experts/spicule.html
@@ -116,27 +116,6 @@
   </div>
 </div>
 
-<div class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      <span class="expert__strap">Juju Expert Partners</span>
-      <h4>
-        Managed solutions partner network. If you are building your own
-        solutions we would love to have you join us as a partner. We can’t wait
-        to talk.
-      </h4>
-    </div>
-    <div class="col-4">
-      <p class="expert__strap">Become a Partner</p>
-      <div class="expert__actions">
-        <a
-          href="mailto:juju-experts@canonical.com"
-          class="p-button--positive">
-          Join us&hellip;
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
+{% include "shared/_expert_partner_cta_strip.html" %}
 
 {% endblock content %}

--- a/templates/jaasai/experts/spicule.html
+++ b/templates/jaasai/experts/spicule.html
@@ -14,7 +14,7 @@
     <div class="col-4">
       <div class="p-card--highlighted">
         {% include "shared/contact-card/_expert-page.html" %}
-      </div
+      </div>
     </div>
   </div>
 </div>

--- a/templates/jaasai/experts/tengu.html
+++ b/templates/jaasai/experts/tengu.html
@@ -109,27 +109,6 @@
   </div>
 </div>
 
-<div class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      <span class="expert__strap">Juju Expert Partners</span>
-      <h4>
-        Managed solutions partner network. If you are building your own
-        solutions we would love to have you join us as a partner. We can&rsquo;t wait
-        to talk.
-      </h4>
-    </div>
-    <div class="col-4">
-      <p class="expert__strap">Become a Partner</p>
-      <div class="expert__actions">
-        <a
-          href="mailto:juju-experts@canonical.com"
-          class="p-button--positive">
-          Join us&hellip;
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
+{% include "shared/_expert_partner_cta_strip.html" %}
 
 {% endblock content %}

--- a/templates/shared/_expert_partner_cta_strip.html
+++ b/templates/shared/_expert_partner_cta_strip.html
@@ -3,9 +3,7 @@
     <div class="col-8">
       <span class="expert__strap">Juju Expert Partners</span>
       <h4>
-        Managed solutions partner network. If you are building your own
-        solutions we would love to have you join us as a partner. We can’t wait
-        to talk.
+        If you are building your own solutions we would love to have you join us as a partner. We can’t wait to talk.
       </h4>
     </div>
     <div class="col-4">

--- a/templates/shared/_expert_partner_cta_strip.html
+++ b/templates/shared/_expert_partner_cta_strip.html
@@ -1,0 +1,20 @@
+<div class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <span class="expert__strap">Juju Expert Partners</span>
+      <h4>
+        Managed solutions partner network. If you are building your own
+        solutions we would love to have you join us as a partner. We can’t wait
+        to talk.
+      </h4>
+    </div>
+    <div class="col-4">
+      <p class="expert__strap">Become a Partner</p>
+      <div class="expert__actions">
+        <a href="mailto:juju-experts@canonical.com" class="p-button--positive">
+          Join us&hellip;
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/shared/_omnivector_lead-gen-form.html
+++ b/templates/shared/_omnivector_lead-gen-form.html
@@ -69,7 +69,7 @@
           </li>
           <li class="mktField submit-wrapper" style="display:flex;margin-top:1rem;">
             <button type="submit" class="mktoButton submit-wrapper__button">Send message</button><input type="hidden" name="formid"
-              class="mktoField " value="3359"><input type="hidden" name="lpId" class="mktoField " value=""><input
+              class="mktoField " value="3450"><input type="hidden" name="lpId" class="mktoField " value=""><input
               type="hidden" name="subId" class="mktoField " value=""><input type="hidden" name="munchkinId"
               class="mktoField " value=""><input type="hidden" name="lpurl" class="mktoField " value=""><input
               type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField "

--- a/templates/shared/_omnivector_lead-gen-form.html
+++ b/templates/shared/_omnivector_lead-gen-form.html
@@ -1,0 +1,89 @@
+<div data-js="contact-form" class="contact-form">
+  <div class="p-modal p-modal--hidden" id="leadGenerationModal">
+    <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+      <header class="p-modal__header">
+        <button class="p-modal__close" aria-label="Close active modal" data-js="modalClose">Close</button>
+      </header>
+      <ul class="modal__contact-list">
+        <li class="modal__website">
+          <span>
+            <img src="https://assets.ubuntu.com/v1/4f94bbf4-icon-web.svg" alt="Email icon">
+          </span>
+          <a href="{{ context.expert.website }}">{{ context.expert.website }}</a>
+        </li>
+        <li class="modal__email">
+          <span>
+            <img src="https://assets.ubuntu.com/v1/5e815088-icon-email.svg" alt="Email icon">
+          </span>
+          <a href="mailto:{{ context.expert.email }}">{{ context.expert.email }}</a>
+        </li>
+        {% for phone in context.expert.phone_numbers %}
+        <li class="modal__tel">
+          <span>
+            <img src="https://assets.ubuntu.com/v1/a52bd3b1-Icon-telephone.svg" alt="Email icon">
+          </span>
+          <a class="modal__tel-link" rel="tel" href="tel:{{ phone.number }}">{{ phone.display }}</a>({{ phone.location }})
+        </li>
+        {% endfor %}
+      </ul>
+      <hr class="modal__divider" />
+      <!-- MARKETO FORM -->
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3355">
+        <ul class="p-list">
+          <li class="mktFormReq mktField">
+            <label for="FirstName" class="mktoLabel ">First Name:</label>
+            <input required id="FirstName" name="FirstName" maxlength="255" type="text"
+              class="mktoField mktoRequired mktoInvalid">
+          </li>
+          <li class="mktFormReq mktField">
+            <label for="LastName" class="mktoLabel ">Last Name:</label>
+            <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired">
+          </li>
+          <li class="mktFormReq mktField">
+            <label for="Email" class="mktoLabel ">Email address:</label>
+            <input required id="Email" name="Email" maxlength="255" type="email"
+              class="mktoField mktoEmailField mktoRequired">
+          </li>
+          <li class="mktFormReq mktField" id="comments">
+            <label for="Comments_from_lead__c" class="mktoLabel ">
+              {% if context and context.entity and context.entity.display_name %}
+                How can we help with <strong>{{ context.entity.display_name }}</strong>?
+              {% else %}
+                How can we help?
+              {% endif %}
+            </label>
+            <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="2"
+              class="mktoField mktoRequired" maxlength="2000"></textarea>
+          </li>
+          <li class="mktField">
+            <label for="canonicalUpdatesOptIn" class="mktoLabel modal__terms">
+              In submitting this form, I confirm that I have read and agree to Canonical’s
+              <a href="https://www.ubuntu.com/legal/data-privacy/contact?_ga=2.67215766.606903877.1552321043-1465573742.1527584293"
+                target="_blank">Privacy Notice</a>, <a
+                href="https://www.ubuntu.com/legal/data-privacy?_ga=2.67215766.606903877.1552321043-1465573742.1527584293"
+                target="_blank">Privacy Policy</a>, <a href="https://static1.squarespace.com/static/5d4f285b0bbd8c0001ab0388/t/5d681714556a300001219f43/1567102740152/Privacy+Policy.pdf" target="_blank">Omnivector's Privacy Policy</a> and acknowledge that I may be contacted by Omnivector and/or Canonical about my form and relevant information.
+            </label>
+          </li>
+          <li class="mktField">
+            <input type="hidden" name="Consent_to_Processing__c" class="mktoField  mktoFormCol" value="Yes">
+          </li>
+          <li class="mktField submit-wrapper" style="display:flex;margin-top:1rem;">
+            <button type="submit" class="mktoButton submit-wrapper__button">Send message</button><input type="hidden" name="formid"
+              class="mktoField " value="3359"><input type="hidden" name="lpId" class="mktoField " value=""><input
+              type="hidden" name="subId" class="mktoField " value=""><input type="hidden" name="munchkinId"
+              class="mktoField " value=""><input type="hidden" name="lpurl" class="mktoField " value=""><input
+              type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField "
+              value=""><input type="hidden" name="q" class="mktoField " value="">
+          </li>
+        </ul>
+        <input type="hidden" name="returnURL" value="{{ expertThanksPage }}/experts/thanks" />
+        <input type="hidden" name="retURL" value="{{ expertThanksPage }}/experts/thanks" />
+      </form>
+      <!-- /MARKETO FORM -->
+    </div>
+  </div>
+</div>
+<script src="{{ static_url('js/app/modal.js') }}"></script>
+<script>
+  window.app.modal('leadGenerationModal');
+</script>

--- a/templates/shared/_omnivector_lead-gen-form.html
+++ b/templates/shared/_omnivector_lead-gen-form.html
@@ -28,7 +28,7 @@
       </ul>
       <hr class="modal__divider" />
       <!-- MARKETO FORM -->
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3355">
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3450">
         <ul class="p-list">
           <li class="mktFormReq mktField">
             <label for="FirstName" class="mktoLabel ">First Name:</label>

--- a/templates/shared/_tengu_lead-gen-form.html
+++ b/templates/shared/_tengu_lead-gen-form.html
@@ -69,7 +69,7 @@
           </li>
           <li class="mktField submit-wrapper" style="display:flex;margin-top:1rem;">
             <button type="submit" class="mktoButton submit-wrapper__button">Send message</button><input type="hidden" name="formid"
-              class="mktoField " value="3359"><input type="hidden" name="lpId" class="mktoField " value=""><input
+              class="mktoField " value="3443"><input type="hidden" name="lpId" class="mktoField " value=""><input
               type="hidden" name="subId" class="mktoField " value=""><input type="hidden" name="munchkinId"
               class="mktoField " value=""><input type="hidden" name="lpurl" class="mktoField " value=""><input
               type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField "

--- a/templates/shared/_tengu_lead-gen-form.html
+++ b/templates/shared/_tengu_lead-gen-form.html
@@ -1,0 +1,89 @@
+<div data-js="contact-form" class="contact-form">
+  <div class="p-modal p-modal--hidden" id="leadGenerationModal">
+    <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+      <header class="p-modal__header">
+        <button class="p-modal__close" aria-label="Close active modal" data-js="modalClose">Close</button>
+      </header>
+      <ul class="modal__contact-list">
+        <li class="modal__website">
+          <span>
+            <img src="https://assets.ubuntu.com/v1/4f94bbf4-icon-web.svg" alt="Email icon">
+          </span>
+          <a href="{{ context.expert.website }}">{{ context.expert.website }}</a>
+        </li>
+        <li class="modal__email">
+          <span>
+            <img src="https://assets.ubuntu.com/v1/5e815088-icon-email.svg" alt="Email icon">
+          </span>
+          <a href="mailto:{{ context.expert.email }}">{{ context.expert.email }}</a>
+        </li>
+        {% for phone in context.expert.phone_numbers %}
+        <li class="modal__tel">
+          <span>
+            <img src="https://assets.ubuntu.com/v1/a52bd3b1-Icon-telephone.svg" alt="Email icon">
+          </span>
+          <a class="modal__tel-link" rel="tel" href="tel:{{ phone.number }}">{{ phone.display }}</a>({{ phone.location }})
+        </li>
+        {% endfor %}
+      </ul>
+      <hr class="modal__divider" />
+      <!-- MARKETO FORM -->
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3443">
+        <ul class="p-list">
+          <li class="mktFormReq mktField">
+            <label for="FirstName" class="mktoLabel ">First Name:</label>
+            <input required id="FirstName" name="FirstName" maxlength="255" type="text"
+              class="mktoField mktoRequired mktoInvalid">
+          </li>
+          <li class="mktFormReq mktField">
+            <label for="LastName" class="mktoLabel ">Last Name:</label>
+            <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired">
+          </li>
+          <li class="mktFormReq mktField">
+            <label for="Email" class="mktoLabel ">Email address:</label>
+            <input required id="Email" name="Email" maxlength="255" type="email"
+              class="mktoField mktoEmailField mktoRequired">
+          </li>
+          <li class="mktFormReq mktField" id="comments">
+            <label for="Comments_from_lead__c" class="mktoLabel ">
+              {% if context and context.entity and context.entity.display_name %}
+                How can we help with <strong>{{ context.entity.display_name }}</strong>?
+              {% else %}
+                How can we help?
+              {% endif %}
+            </label>
+            <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="2"
+              class="mktoField mktoRequired" maxlength="2000"></textarea>
+          </li>
+          <li class="mktField">
+            <label for="canonicalUpdatesOptIn" class="mktoLabel modal__terms">
+              In submitting this form, I confirm that I have read and agree to Canonical’s
+              <a href="https://www.ubuntu.com/legal/data-privacy/contact?_ga=2.67215766.606903877.1552321043-1465573742.1527584293"
+                target="_blank">Privacy Notice</a>, <a
+                href="https://www.ubuntu.com/legal/data-privacy?_ga=2.67215766.606903877.1552321043-1465573742.1527584293"
+                target="_blank">Privacy Policy</a>, <a href="https://www.tengu.io/privacy-policy" target="_blank">Tengu's Privacy Policy</a> and acknowledge that I may be contacted by Tengu and/or Canonical about my form and relevant information.
+            </label>
+          </li>
+          <li class="mktField">
+            <input type="hidden" name="Consent_to_Processing__c" class="mktoField  mktoFormCol" value="Yes">
+          </li>
+          <li class="mktField submit-wrapper" style="display:flex;margin-top:1rem;">
+            <button type="submit" class="mktoButton submit-wrapper__button">Send message</button><input type="hidden" name="formid"
+              class="mktoField " value="3359"><input type="hidden" name="lpId" class="mktoField " value=""><input
+              type="hidden" name="subId" class="mktoField " value=""><input type="hidden" name="munchkinId"
+              class="mktoField " value=""><input type="hidden" name="lpurl" class="mktoField " value=""><input
+              type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField "
+              value=""><input type="hidden" name="q" class="mktoField " value="">
+          </li>
+        </ul>
+        <input type="hidden" name="returnURL" value="{{ expertThanksPage }}/experts/thanks" />
+        <input type="hidden" name="retURL" value="{{ expertThanksPage }}/experts/thanks" />
+      </form>
+      <!-- /MARKETO FORM -->
+    </div>
+  </div>
+</div>
+<script src="{{ static_url('js/app/modal.js') }}"></script>
+<script>
+  window.app.modal('leadGenerationModal');
+</script>

--- a/templates/shared/contact-card/_card.html
+++ b/templates/shared/contact-card/_card.html
@@ -11,6 +11,11 @@
         Get in touch
       </button>
       {% include "shared/_spicule_lead-gen-form.html" %}
+    {% elif context.expert.username == "omnivector"  %}
+      <button data-js="leadGenerationModalTrigger" class="p-button--positive">
+        Get in touch
+      </button>
+      {% include "shared/_omnivector_lead-gen-form.html" %}
     {% else %}
       <a href="#_" data-js="show-btn" class="p-button--positive"
         onclick="dataLayer.push({

--- a/templates/shared/contact-card/_card.html
+++ b/templates/shared/contact-card/_card.html
@@ -16,6 +16,11 @@
         Get in touch
       </button>
       {% include "shared/_omnivector_lead-gen-form.html" %}
+    {% elif context.expert.username == "tengu-team"  %}
+      <button data-js="leadGenerationModalTrigger" class="p-button--positive">
+        Get in touch
+      </button>
+      {% include "shared/_tengu_lead-gen-form.html" %}
     {% else %}
       <a href="#_" data-js="show-btn" class="p-button--positive"
         onclick="dataLayer.push({

--- a/templates/shared/store-card/_random.html
+++ b/templates/shared/store-card/_random.html
@@ -2,6 +2,6 @@
 {% if random_promo == 1 %}
   {% set expert = context.experts['spiculecharms'] %}
 {% elif random_promo == 2 %}
-  {% set expert = context.experts['tengu-team'] %}
+  {% set expert = context.experts['omnivector'] %}
 {% endif %}
 {% include "shared/store-card/_card.html" %}

--- a/webapp/jaasai/views.py
+++ b/webapp/jaasai/views.py
@@ -85,16 +85,24 @@ def experts_spicule():
 
 @jaasai.route("/experts/tengu")
 def experts_tengu():
+    EXPERTS_RETURN = os.environ.get(
+        "EXPERTS_RETURN", default="https://jaas.ai"
+    )
     return render_template(
         "jaasai/experts/tengu.html",
+        expertThanksPage=EXPERTS_RETURN,
         context={"expert": get_experts("tengu-team")},
     )
 
 
 @jaasai.route("/experts/omnivector")
 def experts_omnivector():
+    EXPERTS_RETURN = os.environ.get(
+        "EXPERTS_RETURN", default="https://jaas.ai"
+    )
     return render_template(
         "jaasai/experts/omnivector.html",
+        expertThanksPage=EXPERTS_RETURN,
         context={"expert": get_experts("omnivector")},
     )
 


### PR DESCRIPTION
## Done

- Add Omnivector & Tengu contact forms
- Add Omnivector rotating promo card to homepage in place of Tengu
- Abstract experts CTA strip into shared partial

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check contact card at http://0.0.0.0:8029/experts/tengu
- Check contact card at http://0.0.0.0:8029/experts/omnivector

## Details

Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/419,
Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/418,
Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/369
