### PR TITLE
Prevent initial hero image from lazy loading

### DIFF
--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -46,6 +46,7 @@
               width="534",
               height="374",
               hi_def=True,
+              lazy=False,
             ) | safe
           }}
         </div>


### PR DESCRIPTION
## Done

Prevent initial hero image from lazy loading

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Very homepage index hero does not lazy load

