### PR TITLE
WIP: Upgrade blog and Markdown python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.http==1.0.1
 canonicalwebteam.flask_base==0.3.3
-canonicalwebteam.blog==2.1.1
+canonicalwebteam.blog==4.0.0
 canonicalwebteam.yaml-responses==1.1.1
 canonicalwebteam.discourse-docs==0.6.4
 canonicalwebteam.search==0.2.0
@@ -11,4 +11,4 @@ Flask==1.1.1
 py-gfm==0.1.4
 jujubundlelib==0.5.6
 theblues==0.5.1
-Markdown==2.6.11
+Markdown==3.1.1

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,7 +1,8 @@
 import flask
 import datetime
 
-from canonicalwebteam.blog.app import BlogExtension
+from canonicalwebteam.blog import BlogViews
+from canonicalwebteam.blog.flask import build_blueprint
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.yaml_responses.flask_helpers import (
     prepare_deleted,
@@ -31,6 +32,10 @@ def create_app(testing=False):
     app.before_request(prepare_deleted())
 
     BlogExtension(app, "JAAS Case Studies", [3513], "lang:en", "/case-studies")
+    blog_views = BlogViews(
+        blog_title="JAAS Case Studies",
+        tag_ids=[3513],
+    )
 
     init_handler(app)
     init_blueprint(app)
@@ -87,4 +92,5 @@ def init_blueprint(app):
     app.register_blueprint(jaasai)
     app.register_blueprint(jaasredirects)
     app.register_blueprint(jaasstore)
+    app.register_blueprint(build_blueprint(blog_views), url_prefix="/case-studies")
     init_docs(app, "/docs")


### PR DESCRIPTION
I pulled these upgrades from the Renovate PR as they were breaking.

This initially fails because;

`py-gfm 0.1.4 has requirement markdown<3.0, but you'll have markdown 3.1.1 which is incompatible.`

..but downgrade Markdown back to `2.6.11` and this error manifests...

```
2019-10-01 14:36:46.136Z ERROR gunicorn.error "Exception in worker process"
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/arbiter.py", line 583, in spawn_worker
    worker.init_process()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/workers/base.py", line 129, in init_process
    self.load_wsgi()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/workers/base.py", line 138, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/app/wsgiapp.py", line 52, in load
    return self.load_wsgiapp()
  File "/usr/local/lib/python3.6/dist-packages/talisker/gunicorn.py", line 146, in load_wsgiapp
    app = super(TaliskerApplication, self).load_wsgiapp()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/app/wsgiapp.py", line 41, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/util.py", line 350, in import_app
    __import__(module)
  File "/Users/barrymcgee/projects/jaas.ai/webapp/app.py", line 4, in <module>
    from canonicalwebteam.blog.app import BlogExtension
ModuleNotFoundError: No module named 'canonicalwebteam.blog.app'
```

Any ideas?