### PR TITLE
Remove pre-2.2 instructions for logging into JAAS from Juju

### DIFF
--- a/templates/jaasai/jaas.html
+++ b/templates/jaasai/jaas.html
@@ -114,10 +114,6 @@
           <h6>2. Register</h6>
           <p>Register the JAAS controller with:</p>
           <p>
-            <pre><code>juju register jimm.jujucharms.com</code></pre>
-          </p>
-          <p>With Juju 2.2 beta and later, registration is not required. Simply:</p>
-          <p>
             <pre><code>juju login jaas</code></pre>
           </p>
         </li>


### PR DESCRIPTION
## Done

Remove some HTML from a template. Nothing major.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/getting-started

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
