### PR TITLE
Audit site head to improve page render time

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -1,39 +1,30 @@
 <!doctype html>
 <html class="no-js" lang="en" dir="ltr" itemscope itemtype="http://schema.org/Product">
 <head>
-  <link rel="preconnect" href="https://www.google-analytics.com">
-  <link rel="preconnect" href="https://assets.ubuntu.com">
-  <link rel="preconnect" href="https://munchkin.marketo.net">
-  <title>{% block title %}JAAS{% endblock %} | Juju</title>
   <meta charset="UTF-8" />
-  <meta name="description" content="{% block description %}{% endblock %}" />
-  <meta name="author" content="Canonical" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/751b08fb-favicon.ico" type="image/x-icon" />
-  <link rel="apple-touch-icon-precomposed" sizes="57x57" href="https://assets.ubuntu.com/v1/6d647124-apple-touch-icon-57x57-precomposed.png"/>
-  <link rel="apple-touch-icon-precomposed" sizes="60x60" href="https://assets.ubuntu.com/v1/5c26c240-apple-touch-icon-60x60-precomposed.png"/>
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://assets.ubuntu.com/v1/5deeb74a-apple-touch-icon-72x72-precomposed.png"/>
-  <link rel="apple-touch-icon-precomposed" sizes="76x76" href="https://assets.ubuntu.com/v1/6c83af14-apple-touch-icon-76x76-precomposed.png"/>
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://assets.ubuntu.com/v1/45cc9e41-apple-touch-icon-114x114-precomposed.png"/>
-  <link rel="apple-touch-icon-precomposed" sizes="120x120" href="https://assets.ubuntu.com/v1/7cdddb82-apple-touch-icon-120x120-precomposed.png"/>
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://assets.ubuntu.com/v1/90e8fdfe-apple-touch-icon-144x144-precomposed.png"/>
-  <link rel="apple-touch-icon-precomposed" sizes="152x152" href="https://assets.ubuntu.com/v1/f03175f6-apple-touch-icon-152x152-precomposed.png"/>
-  <link rel="apple-touch-icon-precomposed" sizes="180x180" href="https://assets.ubuntu.com/v1/905b8df0-apple-touch-icon-180x180-precomposed.png"/>
-  <link rel="apple-touch-icon-precomposed" href="https://assets.ubuntu.com/v1/905b8df0-apple-touch-icon-precomposed.png"/>
-
-  <!-- google fonts -->
-  <link href='https://fonts.googleapis.com/css?family=Ubuntu:400,300,300italic,400italic,700,700italic%7CUbuntu+Mono' rel='stylesheet' type='text/css' />
-
-  <!-- stylesheets -->
-  <link rel="stylesheet" type="text/css" media="screen" href="{{ static_url('css/styles.css') }}" />
-
+  <title>{% block title %}JAAS{% endblock %} | Juju</title>
+  <!-- Preconnect domains -->
+  <link rel="preconnect" href="https://www.google-analytics.com">
+  <link rel="preconnect" href="https://munchkin.marketo.net">
+  <!-- Inline scripts -->
   <script>window.app = {utils: {}};</script>
-
+  <!-- Stylesheets -->
+  <link rel="stylesheet" type="text/css" media="screen" href="{{ static_url('css/styles.css') }}" />
+  <!-- External scripts -->
+  <script src="{{ static_url('js/dist/app.min.js') }}" defer></script>
+  <script src="https://assets.ubuntu.com/v1/842d27d3-lazysizes.min.js" defer></script>
+  <!-- Touch/Favicon Icons -->
+  <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/751b08fb-favicon.ico" type="image/x-icon" />
+  <link rel="apple-touch-icon" href="https://assets.ubuntu.com/v1/905b8df0-apple-touch-icon-180x180-precomposed.png"/>
+  <!-- SEO -->
+  <meta name="description" content="{% block description %}{% endblock %}" />
+  <!-- Twitter Opengraph tags -->
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@juju_devops">
   <meta name="twitter:creator" content="@juju_devops">
   <meta name="twitter:domain" content="jaas.ai">
-  <meta name="twitter:title" content="Jujucharms | Juju">
+  <meta name="twitter:title" content="JAAS | Juju as a service">
   <meta name="twitter:description" content="Juju is an open source, application and service modelling tool from Canonical that helps you deploy, manage, and scale your applications on any cloud.">
   <meta name="twitter:image" content="https://assets.ubuntu.com/v1/01868685-juju-twitter.png">
 </head>
@@ -122,8 +113,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
   </div>
 </footer>
-<script defer src="{{ static_url('js/dist/app.min.js') }}"></script>
-<script src="https://assets.ubuntu.com/v1/842d27d3-lazysizes.min.js" async></script>
 <!-- begin usabilla live embed code -->
 <script type="text/javascript">/*{literal}<![CDATA[*/window.lightningjs||function(c){function g(b,d){d&&(d+=(/\?/.test(d)?"&":"?")+"lv=1");c[b]||function(){var i=window,h=document,j=b,g=h.location.protocol,l="load",k=0;(function(){function b(){a.P(l);a.w=1;c[j]("_load")}c[j]=function(){function m(){m.id=e;return c[j].apply(m,arguments)}var b,e=++k;b=this&&this!=i?this.id||0:0;(a.s=a.s||[]).push([e,b,arguments]);m.then=function(b,c,h){var d=a.fh[e]=a.fh[e]||[],j=a.eh[e]=a.eh[e]||[],f=a.ph[e]=a.ph[e]||[];b&&d.push(b);c&&j.push(c);h&&f.push(h);return m};return m};var a=c[j]._={};a.fh={};a.eh={};a.ph={};a.l=d?d.replace(/^\/\//,(g=="https:"?g:"http:")+"//"):d;a.p={0:+new Date};a.P=function(b){a.p[b]=new Date-a.p[0]};a.w&&b();i.addEventListener?i.addEventListener(l,b,!1):i.attachEvent("on"+l,b);var q=function(){function b(){return["<head></head><",c,' onload="var d=',n,";d.getElementsByTagName('head')[0].",d,"(d.",g,"('script')).",i,"='",a.l,"'\"></",c,">"].join("")}var c="body",e=h[c];if(!e)return setTimeout(q,100);a.P(1);var d="appendChild",g="createElement",i="src",k=h[g]("div"),l=k[d](h[g]("div")),f=h[g]("iframe"),n="document",p;k.style.display="none";e.insertBefore(k,e.firstChild).id=o+"-"+j;f.frameBorder="0";f.id=o+"-frame-"+j;/MSIE[ ]+6/.test(navigator.userAgent)&&(f[i]="javascript:false");f.allowTransparency="true";l[d](f);try{f.contentWindow[n].open()}catch(s){a.domain=h.domain,p="javascript:var d="+n+".open();d.domain='"+h.domain+"';",f[i]=p+"void(0);"}try{var r=f.contentWindow[n];r.write(b());r.close()}catch(t){f[i]=p+'d.write("'+b().replace(/"/g,String.fromCharCode(92)+'"')+'");d.close();'}a.P(2)};a.l&&setTimeout(q,0)})()}();c[b].lv="1";return c[b]}var o="lightningjs",k=window[o]=g(o);k.require=g;k.modules=c}({});
 window.usabilla_live = lightningjs.require("usabilla_live", "//w.usabilla.com/3dcbd8f54975.js");


### PR DESCRIPTION
## Done

- Remove redundant Google fonts call
- Deferred non-critical scripts
- Remove redundant apple icons
- Reordered head tags
- Cross ref with:

<img width="575" alt="Screenshot 2019-10-09 at 11 00 14" src="https://user-images.githubusercontent.com/505570/66471868-03180800-ea84-11e9-8e43-8551ffcd57cf.png">


## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Verify all tests pass
- Sanity check code

