### PR TITLE
Tweak JAAS logo on homepage

### DIFF
--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -171,7 +171,7 @@
         <div class="p-card u-align--center">
           {{
             image(
-              url="https://assets.ubuntu.com/v1/a559e2c5-jaas-black-orange-hz-hex.svg",
+              url="https://assets.ubuntu.com/v1/5a2091ba-image+%281%29.svg",
               alt="JAAS logo",
               width="114",
               height="64",


### PR DESCRIPTION
## Done

Tweak JAAS logo on homepage

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check logo on homepage loads correctly

## Details

Fixes #430 
