### PR TITLE
Track requests log

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ Flask-Testing==0.7.1
 Flask==1.1.1
 py-gfm==0.1.4
 jujubundlelib==0.5.6
-theblues==0.5.1
+theblues==0.5.2
 Markdown==2.6.11

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,6 +1,7 @@
 import flask
 import datetime
 
+import talisker.requests
 from canonicalwebteam.blog.app import BlogExtension
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.yaml_responses.flask_helpers import (
@@ -12,6 +13,7 @@ from webapp.external_urls import external_urls
 from webapp.handlers import add_headers
 from webapp.jaasai.views import jaasai
 from webapp.redirects.views import jaasredirects
+from webapp.store.models import cs
 from webapp.store.views import jaasstore
 from webapp.template_utils import current_url_with_query, static_url
 from webapp.docs.views import init_docs
@@ -31,6 +33,7 @@ def create_app(testing=False):
     app.before_request(prepare_deleted())
 
     BlogExtension(app, "JAAS Case Studies", [3513], "lang:en", "/case-studies")
+    talisker.requests.configure(cs.session)
 
     init_handler(app)
     init_blueprint(app)

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -15,6 +15,8 @@ terms = Terms("https://api.jujucharms.com/terms/")
 
 SEARCH_LIMIT = 400
 
+markdown = markdown.Markdown(extensions=[GithubFlavoredMarkdownExtension()])
+
 
 def search_entities(
     query,
@@ -221,9 +223,7 @@ class Entity:
             :content string: Some markdown.
             :returns: HTML as a string.
         """
-        html = markdown.markdown(
-            content, extensions=[GithubFlavoredMarkdownExtension()]
-        )
+        html = markdown.convert(content)
         try:
             html = self._convert_http_to_https(html)
         except Exception:


### PR DESCRIPTION
## Done

- Only configure markdown extension at start of the application (cleans a lot the logs)
- Configure the request session for better logs thanks to talisker

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- check that you have `talisker.requests` logs now!
- try pages where markdown is rendered and make sure it looks as usual
