### PR TITLE
Remove linkchecker 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,32 +7,6 @@ defaults: &defaults
 
 version: 2
 jobs:
-  linkchecker:
-    <<: *defaults
-    steps:
-      - checkout
-      - run:
-          name: Install Linkchecker
-          command: apt-get install -y linkchecker
-      - run:
-          name: Yarn install
-          command: yarn install
-      - run:
-          name: Yarn build
-          command: yarn build
-      - run:
-          name: Install dependencies
-          command: pip3 install -r requirements.txt
-      - run:
-          name: Start development server
-          command: ./entrypoint 0.0.0.0:8029
-          background: true
-      - run:
-          name: Wait for development server
-          command: sleep 5
-      - run:
-          name: Run Linkchecker
-          command: linkchecker --threads 2 -r 2 --verbose --ignore-url /docs/* --ignore-url /search/* --ignore-url /store/* --ignore-url ".*(?:png|jpg|jpeg|gif|bmp|svg|js)$" --ignore-url /q_auto --ignore-url /case-studies --ignore-url /fl_sanitize --ignore-url /w_* --no-warnings http://0.0.0.0:8029
   check-build:
     <<: *defaults
     steps:
@@ -77,7 +51,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - linkchecker
       - check-build
       - python-lint
       - scss-lint


### PR DESCRIPTION
The linkchecker has too many spurious failures with the current charmstore. This removes it, but we should add it back in when the charmstore issues are resolved.  

## QA

If CI passes then it's OK.

