### PR TITLE
Add title to command page

### DIFF
--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -32,7 +32,9 @@ def init_docs(app, url_prefix):
         discourse_parser.parse()
 
         return flask.render_template(
-            "docs/commands.html", navigation=discourse_parser.navigation
+            "docs/commands.html",
+            document={"title": "Command reference"},
+            navigation=discourse_parser.navigation,
         )
 
     app.add_url_rule(


### PR DESCRIPTION
## Done

Fix https://sentry.is.canonical.com/canonical/jaas-ai/issues/4330/
The /docs/commands page was 500.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/docs/commands
- this should work and not 500