### PR TITLE
Reduce navigation breakpoint for docs layout

### DIFF
--- a/static/sass/custom/_patterns_docs.scss
+++ b/static/sass/custom/_patterns_docs.scss
@@ -13,7 +13,7 @@
     flex: 0 0 $sidebar-width;
     top: 0;
 
-    @media only screen and (max-width: $breakpoint-navigation-threshold) {
+    @media only screen and (max-width: $breakpoint-medium) {
       border-bottom: $border;
       border-right: 0;
       flex: auto;
@@ -29,7 +29,7 @@
     margin-top: 0;
     overflow: hidden;
 
-    @media only screen and (max-width: $breakpoint-navigation-threshold) {
+    @media only screen and (max-width: $breakpoint-medium) {
       flex: auto;
     }
 
@@ -45,6 +45,7 @@
 
   .l-docs-row {
     @extend .row;
+
     margin-left: inherit;
     padding: 0 $sp-xxx-large;
 


### PR DESCRIPTION
From Usabilia report - 

_"I am using google chrome on iPad. In landscape mode there is no text associated with any of the TOC entries. In portrait mode, there is text but no TOC."_

## Done

The mobile menu was appearing as 100% width until the screen width was greater than `$breakpoint-large` which is `1680px`. This change corrects this so that the mobile width is only 100% until the screen width is greater than `768px`.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Test `/docs/` by emulating an iPad in landscape mode and verify that sidebar and content are side-by-side.. (and on all devices with screen width greater than 768px)

## Details

Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/482
