### PR TITLE
Remove the external icon fron the discourse link

### DIFF
--- a/templates/shared/header.html
+++ b/templates/shared/header.html
@@ -35,7 +35,7 @@
             </a>
         </li>
         <li class="p-navigation__link" role="menuitem">
-          <a class="p-link--external" href="{{ external_urls.discourse }}">Discourse</a>
+          <a href="{{ external_urls.discourse }}">Discourse</a>
         </li>
         <li class="p-navigation__link {% if active_section == 'docs' %}is-selected{% endif %}" role="menuitem">
           <a href="{{ url_for('discourse_docs.document_view') }}">Docs</a>


### PR DESCRIPTION
## Done
Removed the external icon from the discourse navigation item as the headers match now.

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Click discourse and see it all looks good
