### PR TITLE
Stop the search striping dash

### DIFF
--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -217,7 +217,6 @@
     {% endif %}
     <div class="row">
       <div class="col-8">
-        {{ context }}
         {% if context.query %}
           <h4>Sorry, your search for <strong>{{ context.query }}</strong> returned 0 results.</h4>
           <p>Try a more specific or different query, try other keywords or learn how to <a href="/docs/authors-charm-writing">create your own solution</a>.</p>

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -217,6 +217,7 @@
     {% endif %}
     <div class="row">
       <div class="col-8">
+        {{ context }}
         {% if context.query %}
           <h4>Sorry, your search for <strong>{{ context.query }}</strong> returned 0 results.</h4>
           <p>Try a more specific or different query, try other keywords or learn how to <a href="/docs/authors-charm-writing">create your own solution</a>.</p>

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -55,7 +55,7 @@ def store():
 @jaasstore.route("/search")
 def search():
     query = request.args.get("q", "")
-    search_terms = query.replace("/", " ").replace("-", " ")
+    search_terms = query.replace("/", " ")
     entity_type = request.args.get("type", None)
     if entity_type not in ["charm", "bundle"]:
         entity_type = None


### PR DESCRIPTION
## Done
Stop stripping dashes from a search query.

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Search for `td-agent` and check it returns the charm
- Check production does not return anything

## Details
Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/491
