### PR TITLE
Multistage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,4 @@ run
 .env.local
 
 # Node is only needed for building, not running
-package.json
 node_modules
-yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,61 @@
-FROM ubuntu:bionic
+# syntax=docker/dockerfile:experimental
 
-# System dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-setuptools python3-pip
+# Build stage: Install python dependencies
+# ===
+FROM ubuntu:bionic AS python-dependencies
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools
+ADD requirements.txt /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt
+
+
+# Build stage: Install yarn dependencies
+# ===
+FROM node:10-slim AS yarn-dependencies
+WORKDIR /srv
+ADD package.json .
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
+
+
+# Build stage: Run "yarn run build-js"
+# ===
+FROM yarn-dependencies AS build-js
+ADD assets/js assets/js
+ADD webpack.config.js .
+RUN yarn run build-js
+
+
+# Build stage: Run "yarn run build-css"
+# ===
+FROM yarn-dependencies AS build-css
+ADD assets/sass assets/sass
+RUN yarn run build-css
+
+
+# Build the production image
+# ===
+FROM ubuntu:bionic
 
 # Python dependencies
 ENV LANG C.UTF-8
-
-# Import code, install code dependencies
 WORKDIR /srv
-COPY . .
-RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
-# Set git commit ID
-ARG COMMIT_ID
-RUN test -n "${COMMIT_ID}"
-ENV COMMIT_ID "${COMMIT_ID}"
+# System dependencies
+#RUN apt-get update && apt-get install --no-install-recommends --yes python3-lib2to3 python3-pkg-resources ca-certificates libsodium-dev
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-lib2to3 python3-pkg-resources
+COPY --from=python-dependencies /root/.local/lib/python3.6/site-packages /root/.local/lib/python3.6/site-packages
+COPY --from=python-dependencies /root/.local/bin /root/.local/bin
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Import code, build assets and mirror list
+ADD . .
+RUN rm -rf package.json yarn.lock .babelrc webpack.config.js
+COPY --from=build-js /srv/assets/js assets/js
+COPY --from=build-css /srv/assets/css assets/css
+
+# Set build ID
+ARG BUILD_ID
+ENV TALISKER_REVISION_ID "${BUILD_ID}"
 
 # Setup commands to run server
 ENTRYPOINT ["./entrypoint"]
 CMD ["0.0.0.0:80"]
-

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
-    "build": "node-sass --omit-source-map-url --include-path node_modules assets/sass --output-style compressed --output assets/css && postcss --no-map --use autoprefixer --replace 'assets/css/**/*.css' && yarn run build-js && yarn run copy-3rd-party-js",
-    "build-css": "node-sass --include-path node_modules assets/sass --output assets/css && postcss --use autoprefixer --replace 'assets/css/**/*.css'",
-    "build-js": "webpack",
+    "build": "yarn run build-css && yarn run build-js",
+    "build-css": "node-sass --omit-source-map-url --include-path node_modules assets/sass --output-style compressed --output assets/css && postcss --no-map --use autoprefixer --replace 'assets/css/**/*.css'",
+    "build-js": "webpack && yarn run copy-3rd-party-js",
     "clean": "rm -rf node_modules yarn-error.log css assets/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "copy-3rd-party-js": "mkdir -p assets/js/modules/global-nav && cp node_modules/@canonical/global-nav/dist/global-nav.js assets/js/modules/global-nav",
     "format-python": "black --line-length 79 tests webapp",


### PR DESCRIPTION
Switch over to multistage build to fix the problem with node version in the build for production.

## QA

``` bash
./run clean  # To prove we don't need it
DOCKER_BUILDKIT=1 docker build --tag jaasai --build-arg BUILD_ID=sdfgds .
docker run -ti -p 8666:80 jaasai
```

Go to http://localhost:8666, check it works a charm.

Then, do:

``` bash
$ curl -I http://localhost:8666
X-VCS-Revision: sdfgds
```

^ Check you see the `BUILD_ID` there.