### PR TITLE
Avoid caching jaas-dashboard clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
 # ===
 FROM node:12 AS build-dashboard
 WORKDIR /srv
+# A cache-busting HTTP call, so we always clone the jaas-dashboard repo
+ADD https://httpbin.org/uuid /dev/null
 RUN git clone https://github.com/canonical-web-and-design/jaas-dashboard /srv
 RUN yarn install
 RUN node_modules/.bin/craco build


### PR DESCRIPTION
The jaas-dashboard clone was being cached in subsequent builds, so we
weren't pulling in the latest version of the repo for every build.

This should fix that. @jkfran found
[this technique](https://stackoverflow.com/questions/36996046/how-to-prevent-dockerfile-caching-git-clone)
of using `ADD` to query https://api.github.com/,
but unfortunately it didn't work for me because I kept getting the error
"invalid not-modified ETag" from GitHub. This
[should have been fixed](https://github.com/moby/buildkit/issues/905)
but the fix doesn't seem to have made its way into latest docker-ce yet.
So at some point in the future we could use this solution.

For the time being I've instead used https://httpbin.org/uuid to create
a cache-busting line in the `Dockerfile` just above the git clone.
This is less efficient, in that the GitHub solution would allow
GitHub to return a 304 if nothing had changed, which would allow
Docker to make use of the further caching below that point, whereas in
this implementation it will simply clone the repo every time. But I
believe this is the best we can do for now.

QA
--

Run `DOCKER_BUILDKIT=1 docker build --tag dashboard .`. Then run it again, check that the `git clone https://github.com/canonical-web-and-design/jaas-dashboard /srv` line runs again.

Now run the image with `docker run -ti -p 8203:80 .` and go to http://localhost:8203, check it works, and http://localhost:8203/models, check it also works.