### PR TITLE
Improve cache-busting for jaas-dashboard clone

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 .circleci
 .codecov
 .git
+!.git/refs/heads/master
 .github
 .gitignore
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
 FROM node:12 AS build-dashboard
 WORKDIR /srv
 # A cache-busting HTTP call, so we always clone the jaas-dashboard repo
-ADD https://httpbin.org/uuid /dev/null
+ADD .git/refs/heads/master /dev/null
 RUN git clone https://github.com/canonical-web-and-design/jaas-dashboard /srv
 RUN yarn install
 RUN node_modules/.bin/craco build
@@ -58,7 +58,7 @@ ENV PATH="/root/.local/bin:${PATH}"
 
 # Import code, build assets and mirror list
 ADD . .
-RUN rm -rf package.json yarn.lock .babelrc webpack.config.js
+RUN rm -rf package.json yarn.lock .babelrc webpack.config.js .git/refs/heads/master
 COPY --from=build-dashboard /srv/build templates/dashboard
 COPY --from=build-js /srv/static/js static/js
 COPY --from=build-css /srv/static/css static/css


### PR DESCRIPTION
Improve on PR #500 by using the local `.git/refs/heads/master`
file instead of `httpbin` for cache-busting.

This makes things a lot more efficient as well as not requiring access
to httpbin.

QA
--

Use QA steps from #500