### PR TITLE
Add redirect to get-started page

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -153,3 +153,4 @@ docs/whats-new: /docs/whats-new-2-6
 docs/help-google/?: /docs/gce-cloud
 support/create: /support
 assets/(?P<path>.*): /static/{path}
+get-started/?: /docs/getting-started-with-juju


### PR DESCRIPTION
## Done
Add redirect from /get-started to the docs page.

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/get-started
- Check it loads the get started docs page
