### PR TITLE
Create explicit route to serve favicon from root

### DIFF
--- a/webapp/jaasai/views.py
+++ b/webapp/jaasai/views.py
@@ -146,7 +146,8 @@ def blog_feed():
 
 
 @jaasai.route("/robots.txt")
-def static_from_root():
+@jaasai.route("/favicon.ico")
+def assets_from_root():
     return send_from_directory(current_app.static_folder, request.path[1:])
 
 


### PR DESCRIPTION
## Done

Create explicit route to serve favicon from root

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check you can serve http://0.0.0.0:8029/robots.txt
- Check you can serve http://0.0.0.0:8029/favicon.ico


