### PR TITLE
Pin werkzeurg to 0.16.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ py-gfm==0.1.4
 jujubundlelib==0.5.6
 theblues==0.5.2
 Markdown==2.6.11
+Werkzeug==0.16.1


### PR DESCRIPTION
## Done

Temporary fix for flask testing:

Toto explanations:
```
well this is an issue https://github.com/jarus/flask-testing/pull/141
flask doens't pin werkzeurg
werkzeurg just made and upgrade to v1 and now libraries that depend on flask and some features of wekzeurg are breaking
the PR above is an example of stuff breaking and we are using it on snap and jaas (and maybe other websites) this means that testing will break and block ...
```

## QA

Make sure tests pass now