### PR TITLE
Whitelist config.js route

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -121,6 +121,7 @@ def init_dashboard(app):
 
         return flask.render_template("dashboard/index.html")
 
+    @app.route("/config.js")
     @app.route("/manifest.json")
     @app.route("/ghost-bundle.svg")
     def dashboard_files():


### PR DESCRIPTION
## Done

JAAS Dashboard requires https://jaas.ai/config.js and is currently broken as it is 404ing. 

This PR whitelists that route in the flask app and updates the Docker script to copy it across from the jaas-dashboard root to jaas.ai root.

I have no way to test this locally so all eyes on please.

## QA

Build and run the docker image:

``` bash
DOCKER_BUILDKIT=1 docker build --tag jaas.ai .
docker run -ti -p 8555:80 jaas.ai
```

Once the server is running from the built image, go to http://localhost:8555/models and check it more-or-less works.
