### PR TITLE
Fix broken <a> tags to /community/cards

### DIFF
--- a/templates/store/bundle-details.html
+++ b/templates/store/bundle-details.html
@@ -110,7 +110,7 @@
 
       <div class="p-card" id="juju-card-embed">
         <h3 class="p-card__title">Embed this bundle</h3>
-        <p>Add this card to your website by copying the code below. <a ref="{{ url_for('jaasai.community_cards') }}">Learn more</a>.</p>
+        <p>Add this card to your website by copying the code below. <a href="{{ url_for('jaasai.community_cards') }}">Learn more</a>.</p>
         <textarea rows="2" cols="70" readonly="readonly" wrap="off" style="color:#666">&lt;script src="https://assets.ubuntu.com/v1/juju-cards-v1.7.2.js"&gt;&lt;/script&gt;
 &lt;div class="juju-card" data-id="{{ context.entity.card_id }}" data-dd&gt;&lt;/div&gt;</textarea>
         <h4>Preview</h4>


### PR DESCRIPTION
This commit fixes the broken "ref" attribute to "href".

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Visit a bundle
- Check that you're able to click the link on the embed widget 