### PR TITLE
Update to focal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ defaults: &defaults
   docker:
     - image: canonicalwebteam/dev
   environment:
+      SECRET_KEY: local_development_fake_key
   working_directory: ~/project
 
 version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build stage: Install python dependencies
 # ===
-FROM ubuntu:bionic AS python-dependencies
+FROM ubuntu:focal AS python-dependencies
 RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools
 ADD requirements.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt
@@ -44,7 +44,7 @@ RUN yarn run build-css
 
 # Build the production image
 # ===
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 # Python dependencies
 ENV LANG C.UTF-8
@@ -52,7 +52,7 @@ WORKDIR /srv
 
 # System dependencies
 RUN apt-get update && apt-get install --no-install-recommends --yes python3-lib2to3 python3-pkg-resources
-COPY --from=python-dependencies /root/.local/lib/python3.6/site-packages /root/.local/lib/python3.6/site-packages
+COPY --from=python-dependencies /root/.local/lib/python3.8/site-packages /root/.local/lib/python3.8/site-packages
 COPY --from=python-dependencies /root/.local/bin /root/.local/bin
 ENV PATH="/root/.local/bin:${PATH}"
 

--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn webapp.app:create_app() --bind $1 --worker-class sync --workers 5 --name talisker-`hostname`"
+RUN_COMMAND="talisker.gunicorn.gevent webapp.app:create_app() --bind $1 --worker-class gevent --name talisker-`hostname`"
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+canonicalwebteam.flask_base==0.6.0
 canonicalwebteam.http==1.0.3
-canonicalwebteam.flask_base==0.4.3
 canonicalwebteam.blog==5.0.0
 canonicalwebteam.yaml-responses==1.1.1
 canonicalwebteam.discourse-docs==0.11.1
@@ -7,7 +7,6 @@ canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.0.0
 feedparser==5.2.1
 Flask-Testing==0.8.0
-Flask==1.1.1
 py-gfm==0.1.4
 jujubundlelib==0.5.6
 theblues==0.5.2


### PR DESCRIPTION
## Done

- Update talisker v0.18.0
- Update docker image to focal
- Update to use gevent

## QA

- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag jaas.ai  .`
-  `docker run -ti -p "8006:80" --env SECRET_KEY=secret_key jaas.ai`
- http://0.0.0.0:8006/
- Play around with the site and make sure it works well 