### PR TITLE
Release banner

### DIFF
--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -5,7 +5,15 @@
 
 {% block content %}
 
-  <div class="p-strip--suru-bottom has-accent is-dark" style="background-size: auto 100%, cover; background-position: right center; background-image: url('https://assets.ubuntu.com/v1/a9dab044-suru-right.svg'), linear-gradient(266deg, #044f66, #022935)">
+<div class="p-strip is-shallow">
+  <div class="row">
+    <div>
+      <strong>We've released our new dashboard!</strong> To access it, <a href="/models">view your models</a> or for more info, read our <a href="#">post on Discourse.</a>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip--suru-bottom has-accent is-dark" style="background-size: auto 100%, cover; background-position: right center; background-image: url('https://assets.ubuntu.com/v1/a9dab044-suru-right.svg'), linear-gradient(266deg, #044f66, #022935)">
     <div id="panel-juju-as-a-service" role="tabpanel" aria-labelledby="juju-as-a-service" class="p-hero-panel u-animate--reveal">
       <div class="row">
         <div class="col-6">

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -8,7 +8,7 @@
 <div class="p-strip is-shallow">
   <div class="row">
     <div>
-      <strong>We've released our new dashboard!</strong> To access it, <a href="/models">view your models</a> or for more info, read our <a href="#">post on Discourse.</a>
+      <strong>We've released our new dashboard!</strong> To access it, <a href="/models">view your models</a> or for more info, read our <a class="p-link--external" href="#">post on Discourse.</a>
     </div>
   </div>
 </div>

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -8,7 +8,7 @@
 <div class="p-strip is-shallow">
   <div class="row">
     <div>
-      <strong>We've released our new dashboard!</strong> To access it, <a href="/models">view your models</a> or for more info, read our <a class="p-link--external" href="#">post on Discourse.</a>
+      <strong>We've released our new dashboard!</strong> To access it, <a href="/models">view your models</a> or for more info, read our <a class="p-link--external" href="https://discourse.juju.is/t/jaas-dashboard-the-new-juju-gui/2978">post on Discourse.</a>
     </div>
   </div>
 </div>

--- a/templates/shared/header.html
+++ b/templates/shared/header.html
@@ -46,7 +46,7 @@
       </ul>
       <ul class="p-navigation__links p-navigation_login" role="menu">
         <li class="p-navigation__link" role="menuitem">
-          <a class="p-link--external" href="/models">Your models</a>
+          <a href="/models">Your models</a>
         </li>
       </ul>
     </nav>

--- a/templates/shared/header.html
+++ b/templates/shared/header.html
@@ -46,7 +46,7 @@
       </ul>
       <ul class="p-navigation__links p-navigation_login" role="menu">
         <li class="p-navigation__link" role="menuitem">
-          <a class="p-link--external" href="{{ external_urls.gui }}">Your models</a>
+          <a class="p-link--external" href="/models">Your models</a>
         </li>
       </ul>
     </nav>


### PR DESCRIPTION
## Done

- Add release banner
- Change models link in nav to /models

Note: blocked for now on Discourse link

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- View release banner
- Check that "Your models" link opens dashboard

Related: https://github.com/canonical-web-and-design/juju-squad/issues/1175
