### PR TITLE
Add images modules to supplementary pages

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://www.googletagmanager.com">
   <link rel="preconnect" href="https://www.google-analytics.com">
   <link rel="preconnect" href="https://munchkin.marketo.net">
+  <link rel="preconnect" href="https://assets.ubuntu.com">
   <!-- Inline scripts -->
   <script>window.app = {utils: {}};</script>
   <!-- Stylesheets -->

--- a/templates/jaasai/big-data.html
+++ b/templates/jaasai/big-data.html
@@ -12,7 +12,17 @@
         <h2 class="p-heading--four" itemprop="description">The setup and configuration of Big Data tools can be very complex and daunting &mdash; Juju frees you to explore, test and evaluate Big Data solutions to choose the one that works best for you.</h2>
       </div>
       <div class="col-6 u-hide--small u-align--center u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/9a372437-big-data-hero-image.svg" alt="" itemprop="image" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/9a372437-big-data-hero-image.svg",
+            alt="",
+            width="300",
+            height="108",
+            hi_def=True,
+            attrs={"style": "width:100%"},
+            loading="eager",
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -183,7 +193,16 @@
         <p class="p-heading--four">Use the bundles above, alter and extend them or create your own. Get involved and find out more by visiting the <a href="http://bigdata.juju.solutions/getstarted">Big data community</a>.</p>
       </div>
       <div class="col-4 u-align--center u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/8adead61-picto-community-orange.svg" alt="A gathering of Ubuntu community" width="300" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/8adead61-picto-community-orange.svg",
+            alt="",
+            width="300",
+            height="300",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
   </div>

--- a/templates/jaasai/community.html
+++ b/templates/jaasai/community.html
@@ -12,7 +12,16 @@
       <p><a href="{{ external_urls.discourse }}">Join us in Discourse&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/8adead61-picto-community-orange.svg" alt="Pictogram" width="300" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/8adead61-picto-community-orange.svg",
+          alt="",
+          width="300",
+          height="300",
+          hi_def=True,
+          loading="eager",
+        ) | safe
+      }}
     </div>
   </div>
 </div>
@@ -23,7 +32,17 @@
       <div class="p-card">
         <h2>OpenStack solutions</h2>
         <div class="p-media-object">
-          <img src="https://assets.ubuntu.com/v1/c598e6a4-james-page.jpg" alt="James Page's profile picture" class="p-media-object__image is-round">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/c598e6a4-james-page.jpg",
+              alt="James Page's profile picture",
+              width="48",
+              height="48",
+              hi_def=True,
+              attrs={"class": "p-media-object__image is-round",},
+              loading="eager",
+            ) | safe
+          }}
           <div class="p-media-object__details">
             <h3 class="p-media-object__title">
               James Page
@@ -37,7 +56,17 @@
       <div class="p-card">
         <h2>PaaS Solutions</h2>
         <div class="p-media-object">
-          <img src="https://assets.ubuntu.com/v1/ba7b418f-chris-donati.jpg" alt="Chris Donati's profile picture" class="p-media-object__image is-round">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/ba7b418f-chris-donati.jpg",
+              alt="Chris Donati's profile picture",
+              width="48",
+              height="48",
+              hi_def=True,
+              attrs={"class": "p-media-object__image is-round"},
+              loading="auto",
+            ) | safe
+          }}
           <div class="p-media-object__details">
             <h3 class="p-media-object__title">
               Chris Donati
@@ -53,7 +82,17 @@
       <div class="p-card">
         <h2>Benchmarking solutions</h2>
         <div class="p-media-object">
-          <img src="https://assets.ubuntu.com/v1/547a6844-adam-israel.jpg" alt="Adam Israel's profile picture" class="p-media-object__image is-round">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/547a6844-adam-israel.jpg",
+              alt="Adam Israel's profile picture",
+              width="48",
+              height="48",
+              hi_def=True,
+              attrs={"class": "p-media-object__image is-round"},
+              loading="eager",
+            ) | safe
+          }}
           <div class="p-media-object__details">
             <h3 class="p-media-object__title">
               Adam Israel
@@ -67,7 +106,17 @@
       <div class="p-card">
         <h2>Database Solutions</h2>
         <div class="p-media-object">
-          <img src="https://assets.ubuntu.com/v1/9b80d0de-philip-stoev.jpg" alt="Philip Stoev's profile picture" class="p-media-object__image is-round">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/9b80d0de-philip-stoev.jpg",
+              alt="Philip Sotev's profile picture",
+              width="48",
+              height="48",
+              hi_def=True,
+              attrs={"class": "p-media-object__image is-round"},
+              loading="auto",
+            ) | safe
+          }}
           <div class="p-media-object__details">
             <h3 class="p-media-object__title">
               Philip Stoev
@@ -90,6 +139,16 @@
     </div>
     <div class="col-4 u-hide--small u-align--center">
       <img src="https://assets.ubuntu.com/v1/02297f92-picto-discussion-orange.svg" alt="" width="100px" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/02297f92-picto-discussion-orange.svg",
+          alt="",
+          width="100",
+          height="100",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -103,7 +162,16 @@
       <p><a href="{{ url_for('jaasai.community_cards') }}" class="p-link--inverted">Create card&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/73fe9909-Card.png" alt="mysql charm and apache mapreduce bundle cards" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/73fe9909-Card.png",
+          alt="mySQL Charm and Apache MapReduce bundle cards",
+          width="473",
+          height="236",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </div>
@@ -125,28 +193,13 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-4">
+    <div class="col-6">
       <h5>Discourse</h5>
       <p>Join the Juju community on our <a href="{{ external_urls.discourse }}">Discourse forum</a>.</p>
     </div>
-    <div class="col-4">
+    <div class="col-6">
       <h5>Freenode</h5>
       <p>Find out more, get help or ask any question on our <a class="p-link--external" href="{{ external_urls.freenode }}">Freenode IRC channel</a>.</p>
-    </div>
-    <div class="col-4">
-      <h5>Social</h5>
-      <ul class="p-inline-list">
-        <li class="p-inline-list__item">
-          <a href="https://www.twitter.com/ubuntucloud">
-            <img src="https://assets.ubuntu.com/v1/6bfc6710-twitter-social.svg" alt="Twitter icon">
-          </a>
-        </li>
-        <li class="p-inline-list__item">
-          <a href="https://www.facebook.com/ubuntucloud">
-            <img src="https://assets.ubuntu.com/v1/ae5e5732-facebook-social.svg" alt="Facebook logo">
-          </a>
-        </li>
-      </ul>
     </div>
   </div>
 </div>

--- a/templates/jaasai/community.html
+++ b/templates/jaasai/community.html
@@ -138,7 +138,6 @@
       <p><a href="https://discourse.juju.is/">Join us in Discourse&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/02297f92-picto-discussion-orange.svg" alt="" width="100px" />
       {{
         image(
           url="https://assets.ubuntu.com/v1/02297f92-picto-discussion-orange.svg",

--- a/templates/jaasai/community.html
+++ b/templates/jaasai/community.html
@@ -135,7 +135,7 @@
   <div class="row">
     <div class="col-8">
       <h4>Or talk to us about starting your own &ldquo;subcommunity&rdquo;, there are hundreds of solutions available; want to be that champion?</h4>
-      <p><a href="https://discourse.jujucharms.com/">Join us in Discourse&nbsp;&rsaquo;</a></p>
+      <p><a href="https://discourse.juju.is/">Join us in Discourse&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 u-hide--small u-align--center">
       <img src="https://assets.ubuntu.com/v1/02297f92-picto-discussion-orange.svg" alt="" width="100px" />

--- a/templates/jaasai/containers.html
+++ b/templates/jaasai/containers.html
@@ -124,7 +124,16 @@
         <p class="p-heading--four">Get involved and find out more by visiting the Special Interest Group <a href="https://github.com/kubernetes/community/blob/master/sig-cluster-ops/README.md">SIG-clusterops</a>, or the <a href="https://groups.google.com/forum/#!forum/kubernetes-users">Kubernetes mailing lists</a>.</p>
       </div>
       <div class="col-4 u-align--center u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/8adead61-picto-community-orange.svg" alt="A gathering of Ubuntu community" width="300" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/8adead61-picto-community-orange.svg",
+            alt="",
+            width="300",
+            height="300",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
   </div>

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -456,7 +456,7 @@
   <div class="row">
     <div class="col-4">
       <blockquote class="p-pull-quote--small has-image">
-        <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg"
+        <img loading="lazy" class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg"
           alt="Spicule logo">
         <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data
           applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse
@@ -466,7 +466,7 @@
     </div>
     <div class="col-4">
       <blockquote class="p-pull-quote--small has-image">
-        <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/f5a5d807-ghent-logo.svg"
+        <img loading="lazy" class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/f5a5d807-ghent-logo.svg"
           alt="Ghent University logo">
         <p class="p-pull-quote__quote">Juju enables you to encapsulate each different part of your infrastructure and lets everything talk to each other. So if you have a web server that's managed by Chef and a database that's deployed by a Docker container, you can have
         the web server talk to the database and the relations between these two very easily.</p>
@@ -475,7 +475,7 @@
     </div>
     <div class="col-4">
       <blockquote class="p-pull-quote--small has-image">
-        <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/393fe2c8-epam.svg" alt="Epam logo">
+        <img loading="lazy" class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/393fe2c8-epam.svg" alt="Epam logo">
         <p class="p-pull-quote__quote">Juju acts as a thin layer on top of your infrastructure that allows all your operational code to talk to each other. And because of this communication layer, a lot of the problems that conventional configuration management systems have just don't exist anymore.</p>
         <cite class="p-pull-quote__citation">Konstantin Boudnik, EPAM Systems</cite>
       </blockquote>

--- a/templates/jaasai/jaas.html
+++ b/templates/jaasai/jaas.html
@@ -17,7 +17,16 @@
       </div>
     </div>
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/e7ae18b9-jaas-logos.svg" alt="Cloud based application logos" style="width:100%;max-width:294px;"/>
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/e7ae18b9-jaas-logos.svg",
+          alt="",
+          width="294",
+          height="212",
+          hi_def=True,
+          loading="eager",
+        ) | safe
+      }}
     </div>
   </div>
 </div>
@@ -69,7 +78,17 @@
       </div>
     </div>
     <div class="col-7 u-align--center">
-      <img src="https://assets.ubuntu.com/v1/c45bb1aa-jaas5.gif" class="p-image--shadowed" alt="Kubernetes overview GIF">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c45bb1aa-jaas5.gif",
+          alt="Kubernetes overview GIF",
+          height="354",
+          width="630",
+          hi_def=True,
+          attrs={"class": "p-image--shadowed"},
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 </div>

--- a/templates/jaasai/kubernetes.html
+++ b/templates/jaasai/kubernetes.html
@@ -51,8 +51,8 @@
           <li class="p-inline-images__item">
             <img loading="eager" class="p-inline-images__logo" alt="vmware" src="https://assets.ubuntu.com/v1/3006b8c7-vmware.svg" />
           </li>
-          <li loading="eager" class="p-inline-images__item">
-            <img class="p-inline-images__logo" alt="lxd" src="https://assets.ubuntu.com/v1/fe9b270c-lxd_black-orange_hex_su.svg" />
+          <li class="p-inline-images__item">
+            <img loading="eager" class="p-inline-images__logo" alt="lxd" src="https://assets.ubuntu.com/v1/fe9b270c-lxd_black-orange_hex_su.svg" />
           </li>
           <li class="p-inline-images__item">
             <img loading="eager" class="p-inline-images__logo" alt="openstack" src="https://assets.ubuntu.com/v1/7934d19b-OpenStack_Logo_Horizontal.svg" />

--- a/templates/jaasai/kubernetes.html
+++ b/templates/jaasai/kubernetes.html
@@ -14,7 +14,17 @@
         <p>The easiest way to automate the deployment, scaling, lifecycle and management of your applications. Operate the latest Kubernetes, from the experts behind Ubuntu and the Kubernetes community.</p>
       </div>
       <div class="col-6 u-vertically-center u-align--center">
-        <img src="https://assets.ubuntu.com/v1/96d35aa4-certified-kubernetes-logo.svg" alt="Kubernetes logo" class="u-hide--small" width="230" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/96d35aa4-certified-kubernetes-logo.svg",
+            alt="Kubernetes logo",
+            width="230",
+            height="309",
+            hi_def=True,
+            attrs={"class": "u-hide--small"},
+            loading="eager",
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -30,28 +40,28 @@
       <div class="col-12">
         <ul class="p-inline-images">
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" alt="AWS" src="https://assets.ubuntu.com/v1/39002345-AmazonWebservices_Logo.svg" />
+            <img loading="eager" class="p-inline-images__logo" alt="AWS" src="https://assets.ubuntu.com/v1/39002345-AmazonWebservices_Logo.svg" />
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" alt="Azure" src="https://assets.ubuntu.com/v1/515658c0-microsoft-azure-763dcdb6a8a3facccca6f538a909f1ec.svg" />
+            <img loading="eager" class="p-inline-images__logo" alt="Azure" src="https://assets.ubuntu.com/v1/515658c0-microsoft-azure-763dcdb6a8a3facccca6f538a909f1ec.svg" />
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" alt="Google Cloud Platform" src="https://assets.ubuntu.com/v1/410984a3-Google-cloud-platform-stacked.svg" />
+            <img loading="eager" class="p-inline-images__logo" alt="Google Cloud Platform" src="https://assets.ubuntu.com/v1/410984a3-Google-cloud-platform-stacked.svg" />
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" alt="vmware" src="https://assets.ubuntu.com/v1/3006b8c7-vmware.svg" />
+            <img loading="eager" class="p-inline-images__logo" alt="vmware" src="https://assets.ubuntu.com/v1/3006b8c7-vmware.svg" />
           </li>
-          <li class="p-inline-images__item">
+          <li loading="eager" class="p-inline-images__item">
             <img class="p-inline-images__logo" alt="lxd" src="https://assets.ubuntu.com/v1/fe9b270c-lxd_black-orange_hex_su.svg" />
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" alt="openstack" src="https://assets.ubuntu.com/v1/7934d19b-OpenStack_Logo_Horizontal.svg" />
+            <img loading="eager" class="p-inline-images__logo" alt="openstack" src="https://assets.ubuntu.com/v1/7934d19b-OpenStack_Logo_Horizontal.svg" />
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" alt="joyent" src="https://assets.ubuntu.com/v1/529822fd-joyent_logo.svg" />
+            <img loading="eager" class="p-inline-images__logo" alt="joyent" src="https://assets.ubuntu.com/v1/529822fd-joyent_logo.svg" />
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" alt="maas" src="https://assets.ubuntu.com/v1/1e783fd8-maas_black-orange_hex.svg" />
+            <img loading="eager" class="p-inline-images__logo" alt="maas" src="https://assets.ubuntu.com/v1/1e783fd8-maas_black-orange_hex.svg" />
           </li>
         </ul>
       </div>
@@ -71,7 +81,7 @@
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="{{ external_urls.charmstore }}~containers/kubernetes-master/icon.svg" alt="Kubernetes icon">
+            <img loading="lazy" class="p-heading-icon__img" src="{{ external_urls.charmstore }}~containers/kubernetes-master/icon.svg" alt="Kubernetes icon">
             <h3 class="p-heading-icon__title">Latest upstream Kubernetes</h3>
           </div>
         </div>
@@ -86,7 +96,7 @@
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="{{ external_urls.charmstore }}~containers/etcd/icon.svg" alt="etcd icon">
+            <img loading="lazy" class="p-heading-icon__img" src="{{ external_urls.charmstore }}~containers/etcd/icon.svg" alt="etcd icon">
             <h3 class="p-heading-icon__title">etcd</h3>
           </div>
         </div>
@@ -100,7 +110,7 @@
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="{{ external_urls.charmstore }}~containers/easyrsa/icon.svg" alt="EasyRSA icon">
+            <img loading="lazy" class="p-heading-icon__img" src="{{ external_urls.charmstore }}~containers/easyrsa/icon.svg" alt="EasyRSA icon">
             <h3 class="p-heading-icon__title">EasyRSA</h3>
           </div>
         </div>
@@ -182,7 +192,16 @@
                 </a>
               </div>
               <div class="col-3 u-align--center u-vertically-center">
-                <img src="https://assets.ubuntu.com/v1/ed4ca9fa-nvidia-logo-white.svg" alt="Nvidia logo">
+                {{
+                  image(
+                    url="https://assets.ubuntu.com/v1/ed4ca9fa-nvidia-logo-white.svg",
+                    alt="Nvidia logo",
+                    width="111",
+                    height="82",
+                    hi_def=True,
+                    loading="lazy",
+                  ) | safe
+                }}
               </div>
             </div>
           </div>
@@ -210,7 +229,7 @@
               <div class="p-card">
                 <div class="p-heading-icon">
                   <div class="p-heading-icon__header">
-                    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/804a5808-prometheus-circle.svg" alt="Prometheus icon">
+                    <img loading="lazy" class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/804a5808-prometheus-circle.svg" alt="Prometheus icon">
                     <h3 class="p-heading-icon__title">
                       <a href="{{ url_for('jaasstore.user_entity', username='prometheus-charmers', charm_or_bundle_name='prometheus', series_or_version=14) }}">
                         Prometheus&nbsp;&rsaquo;
@@ -225,7 +244,7 @@
               <div class="p-card">
                 <div class="p-heading-icon">
                   <div class="p-heading-icon__header">
-                    <img class="p-heading-icon__img" src="{{ external_urls.charmstore }}trusty/elasticsearch/icon.svg" alt="ElasticSearch icon">
+                    <img loading="lazy" class="p-heading-icon__img" src="{{ external_urls.charmstore }}trusty/elasticsearch/icon.svg" alt="ElasticSearch icon">
                     <h3 class="p-heading-icon__title">
                       <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='elasticsearch', series_or_version='trusty', version=19) }}">
                         ElasticSearch&nbsp;&rsaquo;
@@ -240,7 +259,7 @@
               <div class="p-card">
                 <div class="p-heading-icon">
                   <div class="p-heading-icon__header">
-                    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/636b94fd-ceph.svg" alt="Ceph icon">
+                    <img loading="lazy" class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/636b94fd-ceph.svg" alt="Ceph icon">
                     <h3 class="p-heading-icon__title">
                       <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='ceph', series_or_version=271) }}">
                         Ceph&nbsp;&rsaquo;
@@ -283,7 +302,6 @@
     <div class="row">
       <div class="col-6">
         <div class="p-card--highlighted">
-
           <div class="p-card__header">
             <h3>
               Kubernetes support plans
@@ -346,7 +364,16 @@
 <div class="p-strip is-bordered">
     <div class="row">
       <div class="col-2">
-        <img class="contact__image" src="https://assets.ubuntu.com/v1/6e61dfbc-picto-quote-k8.svg" alt="" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/6e61dfbc-picto-quote-k8.svg",
+            alt="",
+            width="109",
+            height="109",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
       <div class="col-10">
         <h2>Get in touch</h2>

--- a/templates/jaasai/openstack.html
+++ b/templates/jaasai/openstack.html
@@ -13,7 +13,16 @@
           <h3 class="p-heading--four">Benefit from a fully integrated and optimised combination of the latest release of Ubuntu Server and the latest release of OpenStack</h3>
         </div>
         <div class="col-6 u-align--center u-vertically-center u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/450d7c2f-openstack-hero.svg" alt="Openstack pictogram" width="100%" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/450d7c2f-openstack-hero.svg",
+              alt="Openstack pictogram",
+              width="251",
+              height="149",
+              hi_def=True,
+              loading="eager"
+            ) | safe
+          }}
         </div>
       </div>
     </div>

--- a/webapp/external_urls.py
+++ b/webapp/external_urls.py
@@ -1,8 +1,8 @@
 external_urls = {
-    "discourse": "https://discourse.jujucharms.com/",
+    "discourse": "https://discourse.juju.is/",
     "blog": "https://blog.ubuntu.com/topics/juju",
     "charmstore": "https://api.jujucharms.com/charmstore/v5/",
-    "discourse": "https://discourse.jujucharms.com/",
+    "discourse": "https://discourse.juju.is/",
     "gui": "https://jujucharms.com/new/",
     "issues": "https://github.com/canonical-web-and-design/jaas.ai/issues",
     "freenode": "http://webchat.freenode.net/?channels=%23juju",

--- a/webapp/tutorials/views.py
+++ b/webapp/tutorials/views.py
@@ -10,7 +10,7 @@ from canonicalwebteam.discourse_docs import (
 
 def init_tutorials(app, url_prefix):
     discourse_parser = DocParser(
-        api=DiscourseAPI(base_url="https://discourse.jujucharms.com/"),
+        api=DiscourseAPI(base_url="https://discourse.juju.is/"),
         index_topic_id=2628,
         category_id=34,
         url_prefix=url_prefix,


### PR DESCRIPTION
## Done

- Bumped the image-template module
- Add images modules to supplementary pages
- Corrected any old Discourse links

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/about
- Open http://0.0.0.0:8029/big-data
- Open http://0.0.0.0:8029/kubernetes
- Open http://0.0.0.0:8029/community
- Open http://0.0.0.0:8029/containers
- Open http://0.0.0.0:8029/openstack
- Check all images load as expected
