### PR TITLE
Add canonical url to entity pages

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -13,6 +13,12 @@
   <script>window.app = {utils: {}};</script>
   <!-- Stylesheets -->
   <link rel="stylesheet" type="text/css" media="screen" href="{{ static_url('css/styles.css') }}" />
+
+  {% if self.canonical_url() %}
+    <!-- Canonical URL if provided -->
+    <link rel="canonical" href="https://jaas.ai/{% block canonical_url %}{% endblock %}" />
+  {% endif %}
+
   <!-- External scripts -->
   <script src="{{ static_url('js/dist/app.js') }}" defer></script>
   <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>

--- a/templates/store/bundle-details.html
+++ b/templates/store/bundle-details.html
@@ -3,6 +3,7 @@
 {% set active_section = "store" %}
 
 {% block title %}{{ context.entity.display_name }}{% endblock %}
+{% block canonical_url %}{{request.path.split('/')[1]}}{% endblock %}
 
 {% block content %}
 

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -3,6 +3,7 @@
 {% set active_section = "store" %}
 
 {% block title %}{{ context.entity.display_name }}{% endblock %}
+{% block canonical_url %}{{request.path.split('/')[1]}}{% endblock %}%
 {% block meta_description %}Deploy {{ context.entity.display_name }} to bare metal and public or private clouds using the Juju GUI or command line.{% endblock %}
 
 {% block meta_tags %}


### PR DESCRIPTION
## Done

Add canonical url to charm and bundle pages to alway point to the un-versioned URL.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Go to any entity page with a version
- View source
- Search for "canonical" and verify correct link 

Fixes #561

