### PR TITLE
Add Canonical URL to entity templates

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -19,7 +19,8 @@
   <!-- Touch Icons -->
   <link rel="apple-touch-icon" href="https://assets.ubuntu.com/v1/905b8df0-apple-touch-icon-180x180-precomposed.png"/>
   <!-- SEO -->
-  <meta name="description" content="{% block description %}{% endblock %}" />
+  <meta name="description" content="{% block meta_description %}{% endblock %}" />
+  {% block head_extra %}
   <!-- Twitter Opengraph tags -->
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@juju_devops">
@@ -28,6 +29,7 @@
   <meta name="twitter:title" content="JAAS | Juju as a service">
   <meta name="twitter:description" content="Juju is an open source, application and service modelling tool from Canonical that helps you deploy, manage, and scale your applications on any cloud.">
   <meta name="twitter:image" content="https://assets.ubuntu.com/v1/01868685-juju-twitter.png">
+  {% endblock %}
 </head>
 
 <body>

--- a/templates/store/bundle-details.html
+++ b/templates/store/bundle-details.html
@@ -4,6 +4,16 @@
 
 {% block title %}{{ context.entity.display_name }}{% endblock %}
 
+{% block head_extra %}
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="@ubuntucloud">
+  <meta name="twitter:creator" content="@ubuntucloud">
+  <meta name="twitter:title" content="{{ context.entity.display_name }} - Juju bundle">
+  <meta name="twitter:image" content="https://assets.ubuntu.com/v1/01868685-juju-twitter.png">
+  <meta name="twitter:description" content="{% if context.entity.description %}{{ context.entity.description|striptags }}{% else %}Deploy {{ context.entity.display_name }} to public or private clouds or even bare metal using the Juju GUI or command line.{% endif %}">
+  <link rel="canonical" href="{{ context.entity.canonical_url }}" />
+{% endblock %}
+
 {% block content %}
 
 {% include "store/_entity-header.html" %}

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -19,9 +19,9 @@
   <meta name="twitter:site" content="@ubuntucloud">
   <meta name="twitter:creator" content="@ubuntucloud">
   <meta name="twitter:title" content="{{ context.entity.display_name }} - Juju charm">
-  <meta name="twitter:image" content="{{ request.route_url('icon-proxy-resize', entity_name=name, size=120, file_type='png') }}">
+  <meta name="twitter:image" content="{{ context.entity.icon }}">
   <meta name="twitter:description" content="{% if context.entity.description %}{{ context.entity.description|striptags }}{% else %}Deploy {{ context.entity.display_name }} to public or private clouds or even bare metal using the Juju GUI or command line.{% endif %}">
-  <link rel="canonical" href="{{ canonical_url }}" />
+  <link rel="canonical" href="{{ context.entity.canonical_url }}" />
 {% endblock %}
 
 {% block content %}

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -52,6 +52,7 @@ class TestStoreModels(unittest.TestCase):
         self.assertEqual(charm.homepage, "https://launchpad.net/apache2-charm")
         self.assertTrue(charm.icon.endswith("apache2-26/icon.svg"))
         self.assertEqual(charm.id, "cs:apache2-26")
+        self.assertEqual(charm.canonical_url, "https://jaas.ai/apache2")
         self.assertTrue(charm.is_charm)
         self.assertEqual(
             charm.options.get("apt-key-id"),

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -217,6 +217,16 @@ class Entity:
         )
         self.tags = self._get_tags()
         self.url = self._ref.jujucharms_id()
+        self.canonical_url = self._get_canonical_url()
+
+    def _get_canonical_url(self):
+        jujucharms_url = self._ref.copy(
+            revision=None, series=None
+        ).jujucharms_url()
+        jaas_url = jujucharms_url.replace(
+            "https://jujucharms.com", "https://jaas.ai"
+        )
+        return jaas_url
 
     def _render_markdown(self, content):
         """Render markdown for the provided content.


### PR DESCRIPTION
## Done
Add canonical rel link to charm and bundle details pages

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/nagios
- Check source. The canonical link should be the same
- Go to /nagios/14 and check the canonical link is to the main one.
- Check a bundle (/canonical-kubernetes/500) works too.

## Details
Fixes #561
