### PR TITLE
Fix issue with markdown parser

### DIFF
--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -129,8 +129,7 @@ class TestStoreModels(unittest.TestCase):
         self.assertTrue(charm.supported)
         self.assertEqual(charm.supported_price, "99")
         self.assertEqual(
-            charm.supported_description,
-            "<p>Great ol' charm<br />\nthis one</p>",
+            charm.supported_description, "<p>Great ol' charm\nthis one</p>",
         )
 
     def test_bundle(self):
@@ -189,8 +188,7 @@ class TestStoreModels(unittest.TestCase):
         self.assertTrue(bundle.supported)
         self.assertEqual(bundle.supported_price, "99")
         self.assertEqual(
-            bundle.supported_description,
-            "<p>Great ol' bundle<br />\nthis one</p>",
+            bundle.supported_description, "<p>Great ol' bundle\nthis one</p>",
         )
 
     def test_bundle_icons(self):

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -3,7 +3,7 @@ import os
 import re
 import markdown
 
-from mdx_gfm import GithubFlavoredMarkdownExtension
+from mdx_partial_gfm import PartialGithubFlavoredMarkdownExtension
 from jujubundlelib import references
 from theblues.charmstore import CharmStore
 from theblues.errors import EntityNotFound, ServerError
@@ -15,7 +15,9 @@ terms = Terms("https://api.jujucharms.com/terms/")
 
 SEARCH_LIMIT = 400
 
-markdown = markdown.Markdown(extensions=[GithubFlavoredMarkdownExtension()])
+markdown = markdown.Markdown(
+    extensions=[PartialGithubFlavoredMarkdownExtension()]
+)
 
 
 def search_entities(


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/487

Replaced parser with `PartialGithubFlavoredMarkdownExtension` as suggested in [this comment ](https://github.com/canonical-web-and-design/jaas.ai/issues/487#issuecomment-577870914)

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/nova-compute
- test different charm pages to make sure that the content seems to be correctly displayed.
