### PR TITLE
Update blog module version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask_base==0.6.3
 canonicalwebteam.http==1.0.3
-canonicalwebteam.blog==6.1.1
+canonicalwebteam.blog==6.2.1
 canonicalwebteam.yaml-responses==1.1.1
 canonicalwebteam.discourse-docs==1.0.1
 canonicalwebteam.search==0.2.1

--- a/templates/blog/_case-study-card.html
+++ b/templates/blog/_case-study-card.html
@@ -3,15 +3,7 @@
     {% if article.image and article.image.source_url %}
     <div class="p-card__image">
       <a href="/case-studies/{{ article.slug }}">
-        <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}"
-          srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }} 460w,
-            https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{ article.image.source_url }} 620w,
-            https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{ article.image.source_url }} 875w"
-          sizes="(min-width: 1031px) 460px,
-            (max-width: 1030px) and (min-width: 876px) 460px,
-            (max-width: 875px) and (min-width: 621px) 875px,
-            (max-width: 620px) and (min-width: 461px) 620px,
-            (max-width: 460px) 460px" alt="">
+        {{ article.image.rendered|safe }}
       </a>
     </div>
     {% endif %}


### PR DESCRIPTION
Update module version and make study cases use the rendered images provided by the module.

## QA

Click on the demo link. Browse to `/case-studies`.

Check that thumbnails are ok. Click on some articles, check the images are fine:
The urls of the images should be pointing to `ubuntu.com/wp-content` not `admin.insights.ubuntu.com/wp-content`
The cloudinary service should be enabled for both thumbnails and article images.
