### PR TITLE
Remove fixed height

### DIFF
--- a/templates/jaasai/big-data.html
+++ b/templates/jaasai/big-data.html
@@ -17,7 +17,6 @@
             url="https://assets.ubuntu.com/v1/9a372437-big-data-hero-image.svg",
             alt="",
             width="300",
-            height="108",
             hi_def=True,
             attrs={"style": "width:100%"},
             loading="eager",


### PR DESCRIPTION
## Done

Fix squashed image on big data page by removing fixed height

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/big-data
- Make sure the image is not squashed

## Screenshots

**No**
![image](https://user-images.githubusercontent.com/2707508/91073083-68d89880-e632-11ea-9d1a-93a8f72ff1f6.png)

**Yes**
![image](https://user-images.githubusercontent.com/2707508/91073098-6d9d4c80-e632-11ea-8edb-6d55cea4d981.png)
