### PR TITLE
Remove dead link from /big-data

### DIFF
--- a/templates/jaasai/big-data.html
+++ b/templates/jaasai/big-data.html
@@ -189,7 +189,7 @@
   <div class="row">
     <div class="u-equal-height">
       <div class="col-8 u-vertically-center">
-        <p class="p-heading--four">Use the bundles above, alter and extend them or create your own. Get involved and find out more by visiting the <a href="http://bigdata.juju.solutions/getstarted">Big data community</a>.</p>
+        <p class="p-heading--four">Use the bundles above, alter and extend them or create your own.</p>
       </div>
       <div class="col-4 u-align--center u-vertically-center">
         {{


### PR DESCRIPTION
## Done

Remove dead link from /big-data

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/big-data
- Scroll to the bottom and verify the link has gone

## Details

fixes #547 

