### PR TITLE
Set width and height to thumbnails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 canonicalwebteam.flask_base==0.6.4
 canonicalwebteam.http==1.0.3
-canonicalwebteam.blog==6.2.3
+canonicalwebteam.blog==6.3.1
 canonicalwebteam.yaml-responses==1.1.1
 canonicalwebteam.discourse-docs==1.0.1
 canonicalwebteam.search==0.2.1
-canonicalwebteam.image-template==1.2.0
+canonicalwebteam.image-template==1.3.1
 feedparser==5.2.1
 Flask-Testing==0.8.0
 py-gfm==0.1.4

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -36,7 +36,11 @@ def create_app(testing=False):
     app.before_request(prepare_deleted())
 
     blog_views = BlogViews(
-        api=BlogAPI(session=session),
+        api=BlogAPI(
+            session=session,
+            thumbnail_width=354,
+            thumbnail_height=180,
+        ),
         blog_title="JAAS Case Studies",
         tag_ids=[3513],
         feed_description="Case Studies from happy JAAS users",


### PR DESCRIPTION
## Done

Fix blog article thumbnails.

## QA

Go to: https://jaas.ai/case-studies
Check the thumbnails, you will notice they do not have the same size.

Go to: https://jaas-ai-588.demos.haus
Check the thumbnails, you will notice they all have the same size(354x180) and cover the whole width of the block.

## Issue

Part of: https://github.com/canonical-web-and-design/canonicalwebteam.blog/pull/153

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/6387619/94831438-a2a47800-0404-11eb-9c3e-ff1842a1aab4.png)

After:
![image](https://user-images.githubusercontent.com/6387619/94833048-91f50180-0406-11eb-9423-a0535aae5427.png)

