### PR TITLE
Add a link to manage the cookie settings in the footer

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -78,6 +78,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <a class="p-link--inverted p-link--external" href="https://www.ubuntu.com/legal">Legal Information</a>
           </li>
           <li class="p-inline-list__item">
+            <a href="" class="p-link--inverted js-revoke-cookie-manager">Manage your tracker settings</a>
+          </li>
+          <li class="p-inline-list__item">
             <a class="p-link--inverted" href="{{ external_urls.issues }}">Report a bug on this site</a>
           </li>
         </ul>


### PR DESCRIPTION
## Done
Add a link to manage the cookie settings in the footer

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Scroll to the footer and click the link
- Check the cookie policy opens again

