### PR TITLE
Resolve console errors

### DIFF
--- a/static/js/src/app.js
+++ b/static/js/src/app.js
@@ -2,7 +2,6 @@
 import * as Sentry from '@sentry/browser';
 import {createNav} from '@canonical/global-nav';
 import {cookiePolicy} from '@canonical/cookie-policy';
-import {fetchLatestNews} from '@canonical/latest-news';
 import searchPanel from './modules/search-panel';
 import showContactDetails from './modules/show-contact-details';
 import copySnippet from './modules/copy-snippet';
@@ -25,15 +24,6 @@ searchPanel();
 
 // Show modal windows
 modal();
-
-// Pull latest news from blog feed
-fetchLatestNews({
-  articlesContainerSelector: '#latest-news-container',
-  articleTemplateSelector: '#articles-template',
-  limit: 2,
-  id: 3612,
-  hostname: 'ubuntu.com',
-});
 
 // Add cookie policy on page load
 cookiePolicy();

--- a/static/js/src/latest-news.js
+++ b/static/js/src/latest-news.js
@@ -1,0 +1,10 @@
+import {fetchLatestNews} from '@canonical/latest-news';
+
+// Pull latest news from blog feed
+fetchLatestNews({
+  articlesContainerSelector: '#latest-news-container',
+  articleTemplateSelector: '#articles-template',
+  limit: 2,
+  tagId: 1286,
+  hostname: 'ubuntu.com',
+});

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -69,7 +69,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
 </script>
 
-<footer class="p-strip--suru-top has-accent is-dark" style="background-size: auto 100%, cover; background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(266deg, #044f66, #022935)">
+<footer class="p-strip--suru-top has-accent is-dark" style="background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(266deg, #044f66, #022935);background-size: auto 100%, cover;">
   <div class="row">
     <div class="col-8">
         <p class="u-no-max-width">&copy; {{ current_year }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>

--- a/templates/jaasai/community.html
+++ b/templates/jaasai/community.html
@@ -213,4 +213,7 @@
     </div>
   </div>
 </div>
+
+<script src="{{ static_url('js/dist/latest-news.js') }}"></script>
+
 {% endblock content %}

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -3,4 +3,5 @@ module.exports = {
   'search-filters': './static/js/src/search-filters.js',
   'search-icons': './static/js/src/search-icons.js',
   'instant-page': './static/js/src/libs/instant-page/instantpage.js',
+  'latest-news': './static/js/src/latest-news.js',
 };


### PR DESCRIPTION
## Done

Resolve error in the console where latest news lib was running on all pages.

<img width="653" alt="Screenshot 2020-10-27 at 12 26 58" src="https://user-images.githubusercontent.com/505570/97301487-bb5f4c80-184f-11eb-9bcb-30806be4a788.png">


## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Ensure no console errors.

## Details

Fixes #576
