### PR TITLE
Add focal filter to charm store

### DIFF
--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -101,8 +101,9 @@
                         context.current_series == 'xenial' or
                         context.current_series == 'bionic' or
                         context.current_series == 'cosmic' or
+                        context.current_series == 'focal' or
                         context.current_series == 'trusty') %}p-list__item--active{% endif %}">
-                        {% for series in ['xenial', 'bionic', 'cosmic', 'trusty'] %}{{ series_tag(series) }}{% endfor %}
+                        {% for series in ['xenial', 'bionic', 'cosmic', 'trusty', 'focal'] %}{{ series_tag(series) }}{% endfor %}
                       </li>
                       <li class="p-list__item {% if context.current_series == 'centos7' %}p-list__item--active{% endif %}">
                         {{ series_tag('centos7') }}


### PR DESCRIPTION
## Done

Add focal filter to charm store

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/search?q=databases
- Click filter dropdown
- Select 'Focal' and see that all results support 'Focal'

## Details

Fixes #580

<img width="876" alt="Screenshot 2020-10-27 at 12 33 01" src="https://user-images.githubusercontent.com/505570/97302144-928b8700-1850-11eb-8151-b88f606d15b3.png">

