### PR TITLE
Set canonical URL to charmhub.io for charms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ jujubundlelib==0.5.6
 theblues==0.5.2
 Markdown==2.6.11
 Werkzeug==1.0.1
+requests==2.24.0

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -21,7 +21,7 @@
   <meta name="twitter:title" content="{{ context.entity.display_name }} - Juju charm">
   <meta name="twitter:image" content="{{ context.entity.icon }}">
   <meta name="twitter:description" content="{% if context.entity.description %}{{ context.entity.description|striptags }}{% else %}Deploy {{ context.entity.display_name }} to public or private clouds or even bare metal using the Juju GUI or command line.{% endif %}">
-  {% if context.entity and context.entity.is_charm %}
+  {% if context.entity and context.entity.is_charm and context.exists_charmhub %}
     <link rel="canonical" href="https://charmhub.io/{{ context.charm_bundle_name }}" />
   {% endif %}
 {% endblock %}

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -21,7 +21,9 @@
   <meta name="twitter:title" content="{{ context.entity.display_name }} - Juju charm">
   <meta name="twitter:image" content="{{ context.entity.icon }}">
   <meta name="twitter:description" content="{% if context.entity.description %}{{ context.entity.description|striptags }}{% else %}Deploy {{ context.entity.display_name }} to public or private clouds or even bare metal using the Juju GUI or command line.{% endif %}">
-  <link rel="canonical" href="{{ context.entity.canonical_url }}" />
+  {% if context.entity and context.entity.is_charm %}
+    <link rel="canonical" href="https://charmhub.io/{{ context.charm_bundle_name }}" />
+  {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -21,7 +21,7 @@
   <meta name="twitter:title" content="{{ context.entity.display_name }} - Juju charm">
   <meta name="twitter:image" content="{{ context.entity.icon }}">
   <meta name="twitter:description" content="{% if context.entity.description %}{{ context.entity.description|striptags }}{% else %}Deploy {{ context.entity.display_name }} to public or private clouds or even bare metal using the Juju GUI or command line.{% endif %}">
-  {% if context.entity and context.entity.is_charm and context.exists_charmhub %}
+  {% if context.entity and context.exists_in_charmhub %}
     <link rel="canonical" href="https://charmhub.io/{{ context.charm_bundle_name }}" />
   {% endif %}
 {% endblock %}

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -161,7 +161,11 @@ def details(charm_or_bundle_name, series_or_version=None, version=None):
         )
         return render_template(
             template,
-            context={"entity": entity, "expert": get_experts(entity.owner)},
+            context={
+                "entity": entity,
+                "expert": get_experts(entity.owner),
+                "charm_bundle_name": charm_or_bundle_name,
+            },
         )
     else:
         return abort(404, "Entity not found {}".format(charm_or_bundle_name))

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,3 +1,4 @@
+import requests
 from flask import Blueprint, abort, request, render_template, Response
 from jujubundlelib import references
 
@@ -156,6 +157,17 @@ def details(charm_or_bundle_name, series_or_version=None, version=None):
         entity = models.get_charm_or_bundle(reference)
 
     if entity:
+        try:
+            response = requests.get(
+                (
+                    f"https://api.snapcraft.io/v2/charms/info/"
+                    f"{charm_or_bundle_name}"
+                )
+            )
+            exists_charmhub = response.status_code == 200
+        except Exception:
+            exists_charmhub = False
+
         template = "store/{}-details.html".format(
             "charm" if entity.is_charm else "bundle"
         )
@@ -165,6 +177,7 @@ def details(charm_or_bundle_name, series_or_version=None, version=None):
                 "entity": entity,
                 "expert": get_experts(entity.owner),
                 "charm_bundle_name": charm_or_bundle_name,
+                "exists_charmhub": exists_charmhub,
             },
         )
     else:

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -164,9 +164,9 @@ def details(charm_or_bundle_name, series_or_version=None, version=None):
                     f"{charm_or_bundle_name}"
                 )
             )
-            exists_charmhub = response.status_code == 200
+            exists_in_charmhub = response.status_code == 200
         except Exception:
-            exists_charmhub = False
+            exists_in_charmhub = False
 
         template = "store/{}-details.html".format(
             "charm" if entity.is_charm else "bundle"
@@ -177,7 +177,7 @@ def details(charm_or_bundle_name, series_or_version=None, version=None):
                 "entity": entity,
                 "expert": get_experts(entity.owner),
                 "charm_bundle_name": charm_or_bundle_name,
-                "exists_charmhub": exists_charmhub,
+                "exists_in_charmhub": exists_in_charmhub,
             },
         )
     else:


### PR DESCRIPTION
## Done

- Set canonical url to charmhub.io for charms

## QA

- `dotrun`
- http://0.0.0.0:8029/grafana
- If the charm exists on charmhub then don't show the canonical url
- otherwise show canonical url to charmhub
- Check that the canonical url is charmhub.io

## Details

Before redirecting the store we can start SEOing the charm pages to charmhub.io/<charmname>