### PR TITLE
Fixes indentation in “Start modelling” section

### DIFF
--- a/templates/jaasai/jaas.html
+++ b/templates/jaasai/jaas.html
@@ -125,6 +125,7 @@
           <h4 class="p-stepped-list__title">
             Start modelling
           </h4>
+          <div class="p-stepped-list__content">
           <h5>On the web</h5>
           <p>Go to <a href="{{ external_urls.gui }}">{{ external_urls.gui }}</a></p>
           <h5>On the command line:</h5>
@@ -139,6 +140,7 @@
           <p>
             <pre><code>juju login jaas</code></pre>
           </p>
+          </div>
         </li>
         <li class="p-stepped-list__item">
           <h4 class="p-stepped-list__title">


### PR DESCRIPTION
## Done

- Fixed indentation in “Start modelling” section

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/jaas
- Scroll to “Getting started” step 3

## Details

Fixes #601 

## Screenshots

![image](https://user-images.githubusercontent.com/19801137/99941279-aa79fc00-2d65-11eb-98f3-696a0088a426.png)

