### PR TITLE
Remove canonicalwebateam.http and use talisker.requests session

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 canonicalwebteam.flask_base==0.7.1
-canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.3.1
 canonicalwebteam.yaml-responses==1.1.1
 canonicalwebteam.discourse-docs==1.0.1

--- a/tests/jaasai/test_views.py
+++ b/tests/jaasai/test_views.py
@@ -40,7 +40,7 @@ class WebappViews(TestCase):
                 response.status_code, 200, "For page: {}".format(url)
             )
 
-    @patch("canonicalwebteam.http.CachedSession.get")
+    @patch("webapp.jaasai.views.session.get")
     def test_blog_feed(self, mock_get):
         feed = "<rss><channel><item><title>Post</title></item></channel></rss>"
         mock_get.return_value = MagicMock(text=feed)
@@ -49,7 +49,7 @@ class WebappViews(TestCase):
         self.assertEqual(len(posts), 1)
         self.assertEqual(posts[0]["title"], "Post")
 
-    @patch("canonicalwebteam.http.CachedSession.get")
+    @patch("webapp.jaasai.views.session.get")
     def test_blog_feed_limit_results(self, mock_get):
         feed = (
             "<rss><channel><item><title>Post</title></item>"
@@ -60,7 +60,7 @@ class WebappViews(TestCase):
         response = self.client.get(url_for("jaasai.blog_feed"))
         self.assertEqual(len(json.loads(response.data)), 2)
 
-    @patch("canonicalwebteam.http.CachedSession.get")
+    @patch("webapp.jaasai.views.session.get")
     def test_blog_feed_invalid(self, mock_get):
         mock_get.return_value = MagicMock(text="")
         response = self.client.get(url_for("jaasai.blog_feed"))

--- a/webapp/jaasai/views.py
+++ b/webapp/jaasai/views.py
@@ -1,6 +1,7 @@
 import feedparser
 import os
-import canonicalwebteam.http
+
+import talisker.requests
 from flask import (
     Blueprint,
     current_app,
@@ -11,7 +12,6 @@ from flask import (
     send_from_directory,
 )
 from jujubundlelib import references
-
 from webapp.experts import get_experts
 from webapp.store.models import cs
 
@@ -19,7 +19,7 @@ jaasai = Blueprint(
     "jaasai", __name__, template_folder="/templates", static_folder="/static"
 )
 
-cached_session = canonicalwebteam.http.CachedSession()
+session = talisker.requests.get_session()
 
 
 @jaasai.route("/")
@@ -135,7 +135,7 @@ def support():
 @jaasai.route("/blog/feed")
 def blog_feed():
     feed_url = "https://admin.insights.ubuntu.com/tag/juju/feed"
-    response = cached_session.get(feed_url)
+    response = session.get(feed_url)
     feed = feedparser.parse(response.text)
     response = None
     if feed.bozo == 1:


### PR DESCRIPTION
## Done

Use talisker.requests session instead of canonicalwebteam.http.CachedSession

## QA

- dotrun and check `/blog/feeds` works.

Potentially fixes #606 