### PR TITLE
Convert canonical-kubernetes to charmed-kubernetes naming

### DIFF
--- a/templates/jaasai/containers.html
+++ b/templates/jaasai/containers.html
@@ -61,7 +61,7 @@
 <div class="p-strip u-no-padding--bottom">
   <div class="row">
     <div class="col-8">
-      <h3>The Charmed Distribution of Kubernetes</h3>
+      <h3>Charmed Kubernetes</h3>
       <p>This is kubernetes-core hooked into an Elastic cluster to aggregate all your container workload logs, and mine and visualize your container infrastructure log messaging. This bundle is geared towards full production usage.</p>
     </div>
   </div>

--- a/templates/jaasai/containers.html
+++ b/templates/jaasai/containers.html
@@ -67,7 +67,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <div class="juju-card juju-card--internal" data-id="canonical-kubernetes"></div>
+      <div class="juju-card juju-card--internal" data-id="charmed-kubernetes"></div>
     </div>
   </div>
 </div>

--- a/templates/jaasai/how-it-works.html
+++ b/templates/jaasai/how-it-works.html
@@ -275,7 +275,7 @@
         <p>
           Bundles may also be optimised for different deployment scenarios
           of the same software &mdash; for example, a scale-out production
-          ready version like <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}">The Charmed
+          ready version like <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}">Charmed
           Kubernetes</a>, or a development friendly test
           version like <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='kubernetes-core') }}">Kubernetes Core</a>.
         </p>

--- a/templates/jaasai/how-it-works.html
+++ b/templates/jaasai/how-it-works.html
@@ -275,7 +275,7 @@
         <p>
           Bundles may also be optimised for different deployment scenarios
           of the same software &mdash; for example, a scale-out production
-          ready version like <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}">The Canonical
+          ready version like <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}">The Canonical
           Distribution of Kubernetes</a>, or a development friendly test
           version like <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='kubernetes-core') }}">Kubernetes Core</a>.
         </p>

--- a/templates/jaasai/how-it-works.html
+++ b/templates/jaasai/how-it-works.html
@@ -275,8 +275,8 @@
         <p>
           Bundles may also be optimised for different deployment scenarios
           of the same software &mdash; for example, a scale-out production
-          ready version like <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}">The Canonical
-          Distribution of Kubernetes</a>, or a development friendly test
+          ready version like <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}">The Charmed
+          Kubernetes</a>, or a development friendly test
           version like <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='kubernetes-core') }}">Kubernetes Core</a>.
         </p>
       </div>

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -262,7 +262,7 @@
                     <img src="https://assets.ubuntu.com/v1/3181c7b2-canonical-kubernetes.svg" alt="Charmed Kubernetes icon" />
                   </span>
                   <span class="icon-list__title">
-                    Canonical Kubernetes&nbsp;&rsaquo;
+                    Charmed Kubernetes&nbsp;&rsaquo;
                   </span>
                 </a>
               </li>

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -37,7 +37,7 @@
 
             <div class="row">
               <div class="col-12">
-                <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}" class="p-button--positive">Deploy Kubernetes</a>
+                <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}" class="p-button--positive">Deploy Kubernetes</a>
                 <a href="{{ url_for('jaasai.jaas') }}#deploy-kubernetes-in-minutes" class="p-link--inverted">
                   Or watch the video
                   <img class="p-icon" src="https://assets.ubuntu.com/v1/0d85260e-play-icon.svg" alt="Play icon" style="position: relative; top: 3px; left: 5px; filter: invert(1);">
@@ -257,9 +257,9 @@
                 </a>
               </li>
               <li class="p-list__item icon-list__item">
-                <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}" class="icon-list__link">
+                <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}" class="icon-list__link">
                   <span class="icon-list__image">
-                    <img src="https://assets.ubuntu.com/v1/3181c7b2-canonical-kubernetes.svg" alt="Canonical Kubernetes icon" />
+                    <img src="https://assets.ubuntu.com/v1/3181c7b2-canonical-kubernetes.svg" alt="Charmed Kubernetes icon" />
                   </span>
                   <span class="icon-list__title">
                     Canonical Kubernetes&nbsp;&rsaquo;

--- a/templates/jaasai/jaas.html
+++ b/templates/jaasai/jaas.html
@@ -71,10 +71,10 @@
     <div class="col-5">
       <h2 id="deploy-kubernetes-in-minutes">Deploy Kubernetes in minutes</h2>
       <p>In partnership with Google, Canonical delivers a ‘pure K8s’ experience, tested across a wide range of clouds and integrated with modern metrics and monitoring.</p>
-      <p>The <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}">Charmed Distribution Of Kubernetes</a> is for full production usage. Start using Kubernetes today.</p>
+      <p>The <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}">Charmed Distribution Of Kubernetes</a> is for full production usage. Start using Kubernetes today.</p>
       <div>
         <a href="{{ url_for('jaasai.kubernetes') }}" class="p-button--neutral">Learn more</a>
-        <a href="{{ external_urls.gui }}?deploy-target=bundle/canonical-kubernetes-21" class="p-button--neutral">Launch Kubernetes</a>
+        <a href="{{ external_urls.gui }}?deploy-target=bundle/charmed-kubernetes-21" class="p-button--neutral">Launch Kubernetes</a>
       </div>
     </div>
     <div class="col-7 u-align--center">

--- a/templates/jaasai/jaas.html
+++ b/templates/jaasai/jaas.html
@@ -71,7 +71,7 @@
     <div class="col-5">
       <h2 id="deploy-kubernetes-in-minutes">Deploy Kubernetes in minutes</h2>
       <p>In partnership with Google, Canonical delivers a ‘pure K8s’ experience, tested across a wide range of clouds and integrated with modern metrics and monitoring.</p>
-      <p>The <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}">Charmed Distribution Of Kubernetes</a> is for full production usage. Start using Kubernetes today.</p>
+      <p>The <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}">Charmed Kubernetes</a> is for full production usage. Start using Kubernetes today.</p>
       <div>
         <a href="{{ url_for('jaasai.kubernetes') }}" class="p-button--neutral">Learn more</a>
         <a href="{{ external_urls.gui }}?deploy-target=bundle/charmed-kubernetes-21" class="p-button--neutral">Launch Kubernetes</a>

--- a/templates/jaasai/kubernetes.html
+++ b/templates/jaasai/kubernetes.html
@@ -281,11 +281,11 @@
           <div class="row p-divider">
             <div class="col-4 p-divider__block">
               <h4><a href="https://medium.com/@samnco/how-we-commoditized-gpus-for-kubernetes-7131f3e9231f" class="p-link--external">The easy way to commoditise GPUs for Kubernetes</a></h4>
-              <p>Setting up your Deep Learning framework is now easier than ever with the new GPU integration of the Charmed Distribution of Kubernetes<a href="#kubernetes-notice"><sup>*</sup></a>. Perfect for production grade, on bare metal or in the cloud.</p>
+              <p>Setting up your Deep Learning framework is now easier than ever with the new GPU integration of Charmed Kubernetes<a href="#kubernetes-notice"><sup>*</sup></a>. Perfect for production grade, on bare metal or in the cloud.</p>
             </div>
             <div class="col-4 p-divider__block">
               <h4><a href="https://blog.ubuntu.com/2017/03/27/job-concurrency-in-kubernetes-lxd-cpu-pinning-to-the-rescue" class="p-link--external">Build a transcoding platform in minutes</a></h4>
-              <p>The Charmed Distribution of Kubernetes enables automatic discovery of GPU devices. Work as well with LXD to get a fine grain control mechanism to orchestrate video workflows and maximise the throughput of your clusters.</p>
+              <p>Charmed Kubernetes enables automatic discovery of GPU devices. Work as well with LXD to get a fine grain control mechanism to orchestrate video workflows and maximise the throughput of your clusters.</p>
             </div>
             <div class="col-4 p-divider__block">
               <h4><a href="https://github.com/deis/workflow" class="p-link--external">Transform your solution into a private PaaS</a></h4>

--- a/templates/jaasai/kubernetes.html
+++ b/templates/jaasai/kubernetes.html
@@ -168,13 +168,13 @@
             <div class="pictogram-bg">
               <object type="image/svg+xml" data="{{ external_urls.charmstore }}bundle/canonical-kubernetes-30/diagram.svg" height="300" class="cluster-card__image" title="Production cluster overview"></object>
             </div>
-            <h3><a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}">Production cluster&nbsp;&rsaquo;</a></h3>
+            <h3><a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}">Production cluster&nbsp;&rsaquo;</a></h3>
             <div class="row">
               <div class="col-4">
                 <p>Progress to a highly available Kubernetes cluster &mdash; 2 masters, 3 workers, 3 etc nodes and API load balancer.</p>
               </div>
               <div class="col-2">
-                <a href="{{ external_urls.gui }}?deploy-target=bundle/canonical-kubernetes" ref="nofollow" class="cluster-card__cta p-button--positive">Deploy</a>
+                <a href="{{ external_urls.gui }}?deploy-target=bundle/charmed-kubernetes" ref="nofollow" class="cluster-card__cta p-button--positive">Deploy</a>
               </div>
             </div>
           </div>

--- a/templates/shared/search-panel.html
+++ b/templates/shared/search-panel.html
@@ -6,7 +6,7 @@
     <div class="col-12">
       <div class="p-search-panel__inner">
         <div class="p-search-panel__main">
-          <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}"
+          <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}"
             class="p-search-panel__featured-link">
             {{
               image(

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -162,7 +162,7 @@ class TestStoreModels(unittest.TestCase):
             "<p>A highly-available, production-grade Kubernetes cluster.</p>",
         )
         self.assertEqual(
-            bundle.display_name, "The Charmed Distribution of Kubernetes"
+            bundle.display_name, "Charmed Kubernetes"
         )
         self.assertEqual(
             bundle.homepage, "https://www.ubuntu.com/kubernetes/docs"

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -161,9 +161,7 @@ class TestStoreModels(unittest.TestCase):
             bundle.description,
             "<p>A highly-available, production-grade Kubernetes cluster.</p>",
         )
-        self.assertEqual(
-            bundle.display_name, "Charmed Kubernetes"
-        )
+        self.assertEqual(bundle.display_name, "Charmed Kubernetes")
         self.assertEqual(
             bundle.homepage, "https://www.ubuntu.com/kubernetes/docs"
         )

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -288,7 +288,7 @@ class Entity:
         # Hack to rename 'canonical kubernetes'. To be removed when display
         # name has been implemented.
         if name == "canonical kubernetes":
-            name = "The Charmed Distribution of Kubernetes"
+            name = "Charmed Kubernetes"
         return name
 
     def _extract_from_commoninfo(self):


### PR DESCRIPTION
## Done

convert canonical-kubernetes to charmed-kubernetes naming

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Look for any instances of `canonical-kubernetes` and that the updated sections with `charmed-kubernetes` still work as expected.

## Details

Fixes #617 