### PR TITLE
Add hiring link to global nav

### DIFF
--- a/static/js/src/app.js
+++ b/static/js/src/app.js
@@ -11,7 +11,7 @@ import modal from './modules/modal';
 Sentry.init({dsn: 'https://5b54e6946be34749935c4dd2d9d01cb8@sentry.is.canonical.com//7'});
 
 // Global nav strip
-createNav({maxWidth: '72rem', showLogins: false});
+createNav({maxWidth: '72rem', showLogins: false , hiring: 'https://juju.is/careers' });
 
 // Contact CTA for /experts
 showContactDetails();


### PR DESCRIPTION
## Done

Add hiring link to the global nav

## QA

- `dotrun`
-  http://0.0.0.0:8029
- Make sure global nav has a we're hiring link to the juju.is careers page

