### PR TITLE
Remove the links to the GUI

### DIFF
--- a/templates/jaasai/experts/omnivector.html
+++ b/templates/jaasai/experts/omnivector.html
@@ -37,7 +37,6 @@
         <li class="p-list__item">Integrates with Omnivector&apos;s custom storage solutions.</li>
         <li class="p-list__item">Scale this bundle up to 1000s of nodes!</li>
       </ul>
-      <a href="{{ external_urls.gui }}?dd=~omnivector/bundle/spark-jupyter-core" class="p-button--positive">Deploy Spark Cluster</a>
 
     </div>
     <div class="col-6">
@@ -56,7 +55,6 @@
           favourite cloud when you are ready to take your solution live.</li>
         <li class="p-list__item">SLURM packaging experts.</li>
       </ul>
-      <a href="{{ external_urls.gui }}?dd=~omnivector/bundle/slurm-core" class="p-button--positive">Deploy SLURM Core</a>
     </div>
   </div>
   <div class="row">
@@ -95,9 +93,6 @@
         <li class="p-list__item">Easily integrate your OpenFOAM based solutions.</li>
         <li class="p-list__item">Custom SLURM application packaging!</li>
       </ul>
-      <a href="{{ external_urls.gui }}?dd=~omnivector/bundle/slurm-openfoam" class="p-button--positive">
-        Deploy SLURM OpenFOAM
-      </a>
     </div>
   </div>
 </div>

--- a/templates/jaasai/experts/spicule.html
+++ b/templates/jaasai/experts/spicule.html
@@ -29,7 +29,6 @@
     <div class="col-6">
       <h3><a href="{{ url_for('jaasstore.user_entity', username='spiculecharms', charm_or_bundle_name='anssr-data-engine') }}">Anssr Data-Engine</a></h3>
       <p>The reference implementation of the Anssr Data Platform, developed by the Juju experts at Spicule.</p>
-      <a href="{{ external_urls.gui }}?dd=~spiculecharms/bundle/anssr-data-engine" class="p-button--positive">Deploy Anssr</a>
     </div>
     <div class="col-6 u-hide--small">
       <div class="pictogram-bg">
@@ -43,12 +42,9 @@
       <p>Running interactive analytics at scale can be a challenge. The supported Druid Hadoop bundle from Spicule allows companies to investigate data both in real time and over huge amounts of historical data, by levering the power of Apache Druid.</p>
       <ul class="p-inline-list">
         <li class="p-inline-list__item">
-          <a href="{{ external_urls.gui }}?dd=~spiculecharms/bundle/druid-hadoop" class="p-button--positive">Deploy Druid Hadoop</a>
-        </li>
-        <li class="p-inline-list__item">
           <span class="play-video-cta">
             <a href="https://www.youtube.com/watch?v=qzeGk_5BCMs" target="_blank">
-              Or watch the video
+              Watch the video
             </a>
           </span>
         </li>

--- a/templates/jaasai/experts/tengu.html
+++ b/templates/jaasai/experts/tengu.html
@@ -38,9 +38,6 @@
           <li class="p-list__item is-ticked">Integrated Python Spark Jobs</li>
           <li class="p-list__item is-ticked">Integrated Zeppelin Notebook</li>
         </ul>
-        <div class="expert__actions">
-          <a href="{{ external_urls.gui }}?dd=~tengu-team/bundle/automate-spark-jobs" class="p-button--positive">Deploy Automate Spark Jobs</a>
-        </div>
       </div>
     </div>
     <div class="col-6">
@@ -55,9 +52,6 @@
           <li class="p-list__item is-ticked">Create custom data flows in Node-RED</li>
           <li class="p-list__item is-ticked">Store the info in MongoDB</li>
         </ul>
-        <div class="expert__actions">
-          <a href="{{ external_urls.gui }}?dd=~tengu-team/bundle/create-custom-data-flows" class="p-button--positive">Deploy Create Custom Data Flows</a>
-        </div>
       </div>
     </div>
   </div>

--- a/templates/jaasai/jaas.html
+++ b/templates/jaasai/jaas.html
@@ -74,7 +74,6 @@
       <p>The <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='charmed-kubernetes') }}">Charmed Kubernetes</a> is for full production usage. Start using Kubernetes today.</p>
       <div>
         <a href="{{ url_for('jaasai.kubernetes') }}" class="p-button--neutral">Learn more</a>
-        <a href="{{ external_urls.gui }}?deploy-target=bundle/charmed-kubernetes-21" class="p-button--neutral">Launch Kubernetes</a>
       </div>
     </div>
     <div class="col-7 u-align--center">
@@ -126,8 +125,6 @@
             Start modelling
           </h4>
           <div class="p-stepped-list__content">
-          <h5>On the web</h5>
-          <p>Go to <a href="{{ external_urls.gui }}">{{ external_urls.gui }}</a></p>
           <h5>On the command line:</h5>
           <h6>1. Install</h6>
           <p>If you haven&apos;t installed Juju yet follow <a href="{{ external_urls.docs }}/getting-started" class="p-link--external">these instructions</a> to get it running on your system.</p>

--- a/templates/jaasai/kubernetes.html
+++ b/templates/jaasai/kubernetes.html
@@ -159,9 +159,6 @@
               <div class="col-4">
                 <p>Start with a Kubernetes cluster of two machines &mdash; one master node and one worker node.</p>
               </div>
-              <div class="col-2">
-                <a href="{{ external_urls.gui }}?deploy-target=bundle/kubernetes-core" ref="nofollow" class="cluster-card__cta p-button--positive">Deploy</a>
-              </div>
             </div>
           </div>
           <div class="col-6">
@@ -172,9 +169,6 @@
             <div class="row">
               <div class="col-4">
                 <p>Progress to a highly available Kubernetes cluster &mdash; 2 masters, 3 workers, 3 etc nodes and API load balancer.</p>
-              </div>
-              <div class="col-2">
-                <a href="{{ external_urls.gui }}?deploy-target=bundle/charmed-kubernetes" ref="nofollow" class="cluster-card__cta p-button--positive">Deploy</a>
               </div>
             </div>
           </div>

--- a/templates/shared/_plan-card.html
+++ b/templates/shared/_plan-card.html
@@ -6,8 +6,5 @@
   <h4>Default plan with standard support</h4>
   <hr>
   <p>{{ context.entity.supported_description|safe }}</p>
-  <a href="{{ external_urls.gui }}?deploy-target={{ context.entity.id }}" class="p-button--positive" rel="nofollow">
-    Deploy {{ context.entity.display_name }}
-  </a>
   <p><a href="{{ context.expert.page_url }}">Learn more about <span style="text-transform:capitalize">{{ context.expert.name }}</span> support</a></p>
 </div>

--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -56,11 +56,6 @@
             <a href="{{ external_urls.docs }}/k8s-cloud" class="p-link--external">docs</a>.
           </p>
         </div>
-      {% else %}
-        <a href="{{ external_urls.gui }}?deploy-target={{ context.entity.id }}"
-          class="p-button--positive" rel="nofollow" style="width:100%">
-          Add to new model
-        </a>
       {% endif %}
     </div>
   </header>


### PR DESCRIPTION
## Done
Remove the links to the GUI across the site

## QA
- Open the demo
- Go to the different expert pages and see there is no deploy button and the page still works
- Go to an entity page and check there is no deploy to model button