### PR TITLE
Bump juju-bundlelib v0.5.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ canonicalwebteam.image-template==1.3.1
 feedparser==6.0.2
 Flask-Testing==0.8.1
 py-gfm==0.1.4
-jujubundlelib==0.5.6
+jujubundlelib==0.5.7
 theblues==0.5.2
 Markdown==2.6.11
 requests==2.25.1


### PR DESCRIPTION
## Done
Bump juju-bundlelib v0.5.7

## QA
- Open the demo
- Go to /search?type=bundle
- Go to /mlflow

## Details
Fixes https://github.com/canonical-web-and-design/jaas.ai/issues/667

