### PR TITLE
Add canonical links to store pages

### DIFF
--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -21,8 +21,8 @@
   <meta name="twitter:title" content="{{ context.entity.display_name }} - Juju charm">
   <meta name="twitter:image" content="{{ context.entity.icon }}">
   <meta name="twitter:description" content="{% if context.entity.description %}{{ context.entity.description|striptags }}{% else %}Deploy {{ context.entity.display_name }} to public or private clouds or even bare metal using the Juju GUI or command line.{% endif %}">
-  {% if context.entity and context.exists_in_charmhub %}
-    <link rel="canonical" href="https://charmhub.io/{{ context.charm_bundle_name }}" />
+  {% if context.charmhub_url %}
+  <link rel="canonical" href="{{ context.charmhub_url }}" />
   {% endif %}
 {% endblock %}
 

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -4,6 +4,20 @@
 
 {% block title %}Search results for {{ context.query }}{% endblock %}
 
+
+{% block head_extra %}
+<!-- Twitter Opengraph tags -->
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@juju_devops">
+<meta name="twitter:creator" content="@juju_devops">
+<meta name="twitter:domain" content="jaas.ai">
+<meta name="twitter:title" content="JAAS | Juju as a service">
+<meta name="twitter:description" content="Juju is an open source, application and service modelling tool from Canonical that helps you deploy, manage, and scale your applications on any cloud.">
+<meta name="twitter:image" content="https://assets.ubuntu.com/v1/01868685-juju-twitter.png">
+
+<link rel="canonical" href="https://charmhub.io?q={{ context.query }}" />
+{% endblock %}
+
 {% block content %}
 {% if context.results_count > 0 %}
   <div class="p-strip is-shallow">

--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -5,6 +5,19 @@
 {% block title %}Store{% endblock %}
 {% block description %}Browse Juju's entire repository of solutions and find Charms or Bundles for any problem, including OpenStack, Big Data, MongoDB and Elastic search.{% endblock %}
 
+{% block head_extra %}
+<!-- Twitter Opengraph tags -->
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@juju_devops">
+<meta name="twitter:creator" content="@juju_devops">
+<meta name="twitter:domain" content="jaas.ai">
+<meta name="twitter:title" content="JAAS | Juju as a service">
+<meta name="twitter:description" content="Juju is an open source, application and service modelling tool from Canonical that helps you deploy, manage, and scale your applications on any cloud.">
+<meta name="twitter:image" content="https://assets.ubuntu.com/v1/01868685-juju-twitter.png">
+
+<link rel="canonical" href="https://charmhub.io" />
+{% endblock %}
+
 {% block content %}
 <div class="p-strip--suru-bottom has-accent is-dark" style="
 background-image: url('https://assets.ubuntu.com/v1/a9dab044-suru-right.svg'), linear-gradient(266deg, #044f66, #022935);

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,4 +1,3 @@
-import requests
 from flask import Blueprint, abort, request, render_template, Response
 from jujubundlelib import references
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -135,17 +135,26 @@ def user_details(username):
 def user_entity(
     username, charm_or_bundle_name, series_or_version=None, version=None
 ):
+    charmhub_url = (
+        "https://charmhub.io/" + username + "-" + charm_or_bundle_name
+    )
     return details(
         charm_or_bundle_name,
         series_or_version=series_or_version,
         version=version,
+        charmhub_url=charmhub_url,
     )
 
 
 @jaasstore.route("/<charm_or_bundle_name>")
 @jaasstore.route("/<charm_or_bundle_name>/<series_or_version>")
 @jaasstore.route("/<charm_or_bundle_name>/<series_or_version>/<version>")
-def details(charm_or_bundle_name, series_or_version=None, version=None):
+def details(
+    charm_or_bundle_name,
+    series_or_version=None,
+    version=None,
+    charmhub_url=None,
+):
     reference = None
     try:
         reference = references.Reference.from_jujucharms_url(request.path[1:])
@@ -157,16 +166,8 @@ def details(charm_or_bundle_name, series_or_version=None, version=None):
         entity = models.get_charm_or_bundle(reference)
 
     if entity:
-        try:
-            response = requests.get(
-                (
-                    f"https://api.snapcraft.io/v2/charms/info/"
-                    f"{charm_or_bundle_name}"
-                )
-            )
-            exists_in_charmhub = response.status_code == 200
-        except Exception:
-            exists_in_charmhub = False
+        if charmhub_url is None:
+            charmhub_url = "https://charmhub.io/" + charm_or_bundle_name
 
         template = "store/{}-details.html".format(
             "charm" if entity.is_charm else "bundle"
@@ -177,7 +178,7 @@ def details(charm_or_bundle_name, series_or_version=None, version=None):
                 "entity": entity,
                 "expert": get_experts(entity.owner),
                 "charm_bundle_name": charm_or_bundle_name,
-                "exists_in_charmhub": exists_in_charmhub,
+                "charmhub_url": charmhub_url,
             },
         )
     else:


### PR DESCRIPTION
## Done
Add canonical links for user charms and bundles and the store page.
Removed the look up for existence as we will be cutting over to redirect to charmhub shortly.

## QA
- Go to /?q=foo and check the source contains `<link rel="canonical" href="https://charmhub.io?q=foo" />`
- Go to /u/canonical-sysadmins/wordpress-services/2 and check the source contains `<link rel="canonical" href="https://charmhub.io/canonical-sysadmins-wordpress-services" />`
- Go to /store and check the source contains `<link rel="canonical" href="https://charmhub.io" />`
- Go to /nagios and see the course contains `<link rel="canonical" href="https://charmhub.io/nagios" />`

## Details
Fixes https://github.com/canonical-web-and-design/app-tribe/issues/510